### PR TITLE
v0.19.0: faster game-page load + don't skip the panel on an early D-pad press

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,32 @@
 # Changelog
 
+## v0.19.0
+
+- **The panel appears far sooner on a game page.** It used to wait for a
+  once-every-2-seconds re-sync to notice the page had finished laying out, so on
+  most page loads it arrived a beat or two after everything else. It now retries
+  in a tight burst as soon as Steam renders the page and stops the moment it has
+  landed.
+- **Store content is fetched the instant the page opens**, in parallel with the
+  page transition and the panel's own setup, instead of only after the panel has
+  mounted. Plugin settings are read once at startup so they are never on that
+  path either.
+- **Content appears in two stages instead of all at once.** The description,
+  trailers, screenshots and details now paint as soon as they arrive rather than
+  waiting for reviews, update history and the Deck report; those sections show a
+  small shimmer and fill in a moment later.
+- **Revisiting a game is instant.** Cached store data past its refresh window is
+  now shown immediately and refreshed in the background, so a game you've opened
+  before never sends you back to the loading placeholder.
+- **Pressing down before the panel appears no longer skips it.** The placeholder
+  is a real selection stop, so the D-pad/stick scrolls into the section instead
+  of jumping straight to the tab strip — and if the press lands in the split
+  second before the panel is in place, it is replayed into the panel once it is,
+  so you end up where the press would have taken you.
+- **Focus is no longer lost when content replaces the placeholder** you were
+  sitting on — the selection moves to the panel's first item instead of dropping
+  out of the panel and scrolling the page back to the top.
+
 ## v0.18.0
 
 - **Fixes the remaining crash in co-installed plugins (SDH-PlayTime).** Even after

--- a/README.md
+++ b/README.md
@@ -50,12 +50,22 @@ Access** panel.
   and above the tab strip — re-providing the page's gamepad-focus node so the
   panel stays controller-navigable. The route patch is read-only. Every step is
   guarded, so a Steam client update degrades to "no panel" rather than crashing.
+- **Getting on screen fast**: the route render starts the store fetch straight
+  away and kicks off a short retry burst that injects the host the moment the
+  page is laid out (a 2 s heartbeat then just covers tab switches and page
+  rebuilds). Store details paint as soon as they land — reviews, update history
+  and the Deck report fill in behind a shimmer — and the loading placeholder is
+  a real gamepad focus stop, so a D-pad press made before the panel appears
+  scrolls into the section instead of skipping past it.
 - **Backend** (`main.py`, Python stdlib only): fetches from Steam's store/web
   APIs (bypassing the browser's CORS restrictions), **normalizes and
   allowlist-sanitizes** the HTML/JSON, converts news BBCODE → safe HTML, resolves
   non-Steam games to a store appid by title search, and caches responses to disk
   (`DECKY_PLUGIN_RUNTIME_DIR`) with per-kind TTLs plus negative caching and
-  in-flight de-duplication to stay well under Steam's rate limits.
+  in-flight de-duplication to stay well under Steam's rate limits. Expired
+  entries are served **stale-while-revalidate** — the last known-good copy is
+  returned immediately and refreshed in the background — so revisiting a game
+  never puts you back on the loading placeholder.
 
 Data sources (no API key required): store **appdetails**, reviews
 (**appreviews** + **appreviewhistogram**), store **search** (`storesearch`, for
@@ -219,6 +229,7 @@ EnhancedGV/
     ├── index.tsx            # definePlugin: registers the route patch + QAM panel
     ├── patchLibraryApp.tsx  # app-page injection (Decky-owned portal, no render-fn patching)
     ├── navBridge.ts         # re-provides Steam's gamepad-focus context to the panel
+    ├── earlyNav.ts          # replays a D-pad press made before the panel landed
     ├── api.ts               # callable() bindings to main.py
     ├── identity.ts          # reads game identity (Steam vs non-Steam shortcut)
     ├── matches.ts           # non-Steam match-change pub/sub

--- a/main.py
+++ b/main.py
@@ -43,6 +43,12 @@ TTL = {"appdetails": 86400, "deck": 86400, "reviews": 3600, "reviews_sum": 3600,
 # Negative results (fetch failed / success=false) are cached only briefly so a
 # transient network/SSL failure doesn't linger after it's resolved.
 NEGATIVE_TTL = 120
+# How long past its TTL a cached entry may still be SERVED while a refresh runs
+# in the background (stale-while-revalidate). Revisiting a game after the TTL
+# expired used to mean sitting on the loading placeholder through a full set of
+# store round-trips; now the last known content paints immediately and the fresh
+# copy replaces it on the next visit. Only positive results go stale-warm.
+STALE_GRACE = 7 * 86400
 
 REQUEST_TIMEOUT = 15
 USER_AGENT = "Mozilla/5.0 (X11; Linux x86_64; SteamDeck) DeckyStorePanel/0.1"
@@ -135,20 +141,26 @@ def _cache_path(kind: str, key: str) -> str:
     return os.path.join(CACHE_DIR, f"{safe}.json")
 
 
-def _read_cache(kind: str, key: str):
+def _read_cache_entry(kind: str, key: str):
+    """-> (data, fresh). `data` is None on a miss; `fresh` is False for an entry
+    that is past its TTL but still inside the stale-serve grace window."""
     path = _cache_path(kind, key)
     try:
         with open(path, "r", encoding="utf-8") as fh:
             blob = json.load(fh)
     except Exception:
-        return None
+        return None, False
     if not isinstance(blob, dict):
-        return None  # corrupt/foreign file -> treat as a cache miss, never raise
+        return None, False  # corrupt/foreign file -> a cache miss, never raise
     age = time.time() - blob.get("fetched_at", 0)
-    ttl = NEGATIVE_TTL if blob.get("negative") else TTL.get(kind, 3600)
+    negative = bool(blob.get("negative"))
+    ttl = NEGATIVE_TTL if negative else TTL.get(kind, 3600)
     if age < ttl:
-        return blob.get("data")
-    return None
+        return blob.get("data"), True
+    # A stale FAILURE is worthless — never serve it; retry instead.
+    if not negative and age < ttl + STALE_GRACE:
+        return blob.get("data"), False
+    return None, False
 
 
 def _write_cache(kind: str, key: str, data, negative: bool = False) -> None:
@@ -822,9 +834,13 @@ class Plugin:
         decky.logger.info("EnhancedGV backend uninstalling")
 
     # --- generic fetch with cache + in-flight dedup ------------------------ #
+    def _clear_inflight(self, inflight_key: str, task) -> None:
+        if getattr(self, "_inflight", {}).get(inflight_key) is task:
+            self._inflight.pop(inflight_key, None)
+
     async def _fetch(self, kind: str, key: str, url: str, normalize):
-        cached = _read_cache(kind, key)
-        if cached is not None:
+        cached, fresh = _read_cache_entry(kind, key)
+        if cached is not None and fresh:
             return cached
 
         # Always schedule on the loop that is executing THIS call. A loop captured
@@ -840,6 +856,10 @@ class Plugin:
         inflight_key = f"{kind}:{key}"
         existing = self._inflight.get(inflight_key)
         if existing is not None and not existing.done():
+            # A stale-but-usable copy beats waiting on the refresh that is
+            # already running for it.
+            if cached is not None:
+                return cached
             return await existing
 
         async def _do():
@@ -864,12 +884,22 @@ class Plugin:
 
         task = asyncio.create_task(_do())
         self._inflight[inflight_key] = task
+        # Always clear the slot when the task ends, so a task nobody awaits
+        # (the background refresh below) can't leave a poisoned entry behind.
+        task.add_done_callback(lambda t: self._clear_inflight(inflight_key, t))
+
+        if cached is not None:
+            # Stale-while-revalidate: answer NOW with the last known-good copy
+            # and let the refresh land in the cache for the next read. `_do`
+            # swallows its own exceptions, so this task never goes unretrieved.
+            return cached
+
         try:
             return await task
         finally:
-            # Pop in the awaiter (not inside _do) so even a cancelled/never-run
-            # task cannot leave a permanent poisoned entry behind.
-            self._inflight.pop(inflight_key, None)
+            # Pop in the awaiter too (not only inside _do) so even a
+            # cancelled/never-run task cannot leave a permanent poisoned entry.
+            self._clear_inflight(inflight_key, task)
 
     # --- individual endpoints ---------------------------------------------- #
     async def get_appdetails(self, appid: int, lang: str = "english", cc: str = "us"):

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "enhancedgv",
-  "version": "0.18.0",
+  "version": "0.19.0",
   "description": "Decky plugin that shows Steam store content (media, description, reviews, Deck compatibility, update history) on the library game page.",
   "type": "module",
   "scripts": {

--- a/plugin.json
+++ b/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "EnhancedGV",
   "author": "Featherwolf",
-  "version": "0.18.0",
+  "version": "0.19.0",
   "flags": [],
   "api_version": 1,
   "publish": {

--- a/src/api.ts
+++ b/src/api.ts
@@ -1,9 +1,25 @@
 import { callable } from "@decky/api";
-import type { AppData, PatchNotes, PluginSettings, Reviews, UpdateInfo } from "./types";
+import type {
+  AppData,
+  AppDetails,
+  PatchNotes,
+  PluginSettings,
+  Reviews,
+  UpdateInfo,
+} from "./types";
 
 // Each string MUST match an `async def` name on the Python `class Plugin`.
 export const getAll = callable<[appid: number, lang: string, cc: string], AppData>(
   "get_all"
+);
+
+// The store-details half of get_all on its own. Requested in parallel with
+// get_all so the hero/description/features can paint as soon as the single
+// appdetails request lands, instead of waiting on reviews + news + deck. The
+// backend de-duplicates in-flight requests per resource, so get_all reuses this
+// very fetch rather than issuing a second one.
+export const getAppDetails = callable<[appid: number, lang: string, cc: string], AppDetails>(
+  "get_appdetails"
 );
 
 export const getSettings = callable<[], PluginSettings>("get_settings");

--- a/src/components/SkeletonPanel.tsx
+++ b/src/components/SkeletonPanel.tsx
@@ -28,6 +28,21 @@ function Skel({ style }: { style: CSSProperties }) {
   return <div className="ssp-skel" style={style} />;
 }
 
+// Placeholder for a single section whose data is still in flight after the
+// first paint (store details land first; reviews / news / Deck report follow).
+// Without it those sections would briefly render their "nothing here" text and
+// then swap to real content, which reads as wrong data rather than as loading.
+export function SectionLoading({ lines = 3 }: { lines?: number }) {
+  return (
+    <div style={{ display: "flex", flexDirection: "column", gap: 8 }}>
+      <style>{SHIMMER_CSS}</style>
+      {Array.from({ length: lines }, (_, i) => (
+        <Skel key={i} style={{ width: `${100 - i * 12}%`, height: 13 }} />
+      ))}
+    </div>
+  );
+}
+
 export function SkeletonPanel({ sections }: { sections: SectionToggles }) {
   const sectionBars =
     [sections.about, sections.features, sections.deck, sections.reviews, sections.news].filter(

--- a/src/components/StorePanel.tsx
+++ b/src/components/StorePanel.tsx
@@ -3,7 +3,7 @@ import type { CSSProperties, ReactNode } from "react";
 import { Focusable } from "@decky/ui";
 import { useAppData } from "../hooks/useAppData";
 import { useResolvedGame } from "../hooks/useResolvedGame";
-import { CENTER_ON_FOCUS, FOCUS_SCROLL_MARGIN } from "../focus";
+import { CENTER_ON_FOCUS, FOCUS_SCROLL_MARGIN, focusFirstStop } from "../focus";
 import {
   setDiag,
   markStoreRender,
@@ -13,7 +13,7 @@ import {
 } from "../diag";
 import { CollapsibleSection } from "./CollapsibleSection";
 import { MediaHero } from "./MediaGallery";
-import { SkeletonPanel } from "./SkeletonPanel";
+import { SkeletonPanel, SectionLoading } from "./SkeletonPanel";
 import { DEFAULT_EXPANDED } from "../types";
 import { DescriptionSection } from "./DescriptionSection";
 import { FeaturesSection } from "./FeaturesSection";
@@ -60,6 +60,44 @@ const HEADER_STYLE: CSSProperties = {
   gap: 10,
   marginBottom: 8,
 };
+
+// Everything the panel shows BEFORE its content exists (skeleton, "not matched
+// yet", "store unavailable") lives inside this, and it is a real focus stop.
+// Otherwise the D-pad walks straight from the Play button to the tab strip while
+// the panel is still loading — the section is skipped instead of scrolled
+// through — and the user never comes back to it once content lands.
+function PlaceholderStop({
+  onFocusChange,
+  children,
+}: {
+  onFocusChange?: (focused: boolean) => void;
+  children: ReactNode;
+}) {
+  const [focused, setFocused] = useState(false);
+  const set = (v: boolean) => {
+    setFocused(v);
+    onFocusChange?.(v);
+  };
+  return (
+    <Focusable
+      {...CENTER_ON_FOCUS}
+      // A no-op activate is what makes Valve's nav treat this as a landing spot
+      // rather than a pass-through container (same trick as ShortDescCard).
+      onActivate={() => {}}
+      onFocus={() => set(true)}
+      onBlur={() => set(false)}
+      style={{
+        ...FOCUS_SCROLL_MARGIN,
+        borderRadius: 6,
+        padding: 2,
+        outline: focused ? "2px solid #1a9fff" : "2px solid transparent",
+        outlineOffset: 2,
+      }}
+    >
+      {children}
+    </Focusable>
+  );
+}
 
 function StatusBanner({ tone, text }: { tone: "info" | "warn"; text: string }) {
   return (
@@ -129,6 +167,27 @@ export function StorePanel({ appid, slot = "primary", fallback }: Props) {
   const fetchAppid = resolved.storeAppid;
   const { data, settings, loading, error } = useAppData(fetchAppid);
   const rootRef = useRef<HTMLDivElement | null>(null);
+
+  // True while the panel has no store content yet (resolving / loading /
+  // unmatched / unavailable) and is therefore showing its placeholder stop.
+  const hasContent = !!(data && data.appdetails?.ok);
+  // Mirrors the three early-return branches below exactly.
+  const showsPlaceholder = resolved.status === "resolving" || loading || !hasContent;
+  // When content replaces the placeholder the user is standing on, the focused
+  // node disappears — Valve's nav would drop the cursor out of the panel and
+  // scroll the page back up. Hand focus to the panel's first real stop instead.
+  const placeholderFocused = useRef(false);
+  const wasPlaceholder = useRef(showsPlaceholder);
+  useEffect(() => {
+    if (wasPlaceholder.current && !showsPlaceholder && placeholderFocused.current) {
+      placeholderFocused.current = false;
+      const raf = requestAnimationFrame(() => focusFirstStop(rootRef.current));
+      wasPlaceholder.current = showsPlaceholder;
+      return () => cancelAnimationFrame(raf);
+    }
+    wasPlaceholder.current = showsPlaceholder;
+    return;
+  }, [showsPlaceholder]);
 
   // Mount health: lets the patcher detect "injection succeeded once but the
   // committed tree lost the panel" and re-arm the fallback ladder. Keyed by
@@ -203,11 +262,13 @@ export function StorePanel({ appid, slot = "primary", fallback }: Props) {
     // content replaces it in place. Also covers the brief "matching a non-Steam
     // game by title" window.
     return (
-      <div ref={rootRef} style={CONTAINER_STYLE}>
+      <Focusable ref={rootRef} style={CONTAINER_STYLE}>
         {chromeHeader}
-        <SkeletonPanel sections={settings.sections} />
+        <PlaceholderStop onFocusChange={(f) => (placeholderFocused.current = f)}>
+          <SkeletonPanel sections={settings.sections} />
+        </PlaceholderStop>
         {fallback}
-      </div>
+      </Focusable>
     );
   }
 
@@ -215,18 +276,20 @@ export function StorePanel({ appid, slot = "primary", fallback }: Props) {
     // A non-Steam game with no Steam store match (auto-search missed, or it's not
     // on Steam). Managed entirely from the QAM — no in-page matcher.
     return (
-      <div ref={rootRef} style={CONTAINER_STYLE}>
+      <Focusable ref={rootRef} style={CONTAINER_STYLE}>
         {chromeHeader}
-        <StatusBanner
-          tone="info"
-          text="This game isn’t matched to a Steam store page yet. Set its Steam App ID from Quick Access → EnhancedGV → Store data source to pull content."
-        />
+        <PlaceholderStop onFocusChange={(f) => (placeholderFocused.current = f)}>
+          <StatusBanner
+            tone="info"
+            text="This game isn’t matched to a Steam store page yet. Set its Steam App ID from Quick Access → EnhancedGV → Store data source to pull content."
+          />
+        </PlaceholderStop>
         {fallback}
-      </div>
+      </Focusable>
     );
   }
 
-  if (error || !data || !data.appdetails?.ok) {
+  if (!hasContent) {
     // Store data unavailable (non-Steam shortcut / region-locked / fetch error).
     // Show the native content as a fallback, but make it clear EnhancedGV IS
     // active and why there's no store content, rather than looking unchanged.
@@ -235,16 +298,22 @@ export function StorePanel({ appid, slot = "primary", fallback }: Props) {
         ? (data.appdetails as { error?: string })?.error
         : error) || "no store data";
     return (
-      <div ref={rootRef} style={CONTAINER_STYLE}>
+      <Focusable ref={rootRef} style={CONTAINER_STYLE}>
         {chromeHeader}
-        <StatusBanner tone="warn" text={`Store content unavailable (${why})`} />
+        <PlaceholderStop onFocusChange={(f) => (placeholderFocused.current = f)}>
+          <StatusBanner tone="warn" text={`Store content unavailable (${why})`} />
+        </PlaceholderStop>
         {fallback}
-      </div>
+      </Focusable>
     );
   }
 
   const d = data.appdetails;
   const sec = settings.sections;
+  // First paint: store details are real, the rest is still in flight. Those
+  // sections show a shimmer rather than their empty state, and their subtitle
+  // (review count, news count, Deck rating) fills in when the data lands.
+  const pending = !!data.partial;
   const expanded = { ...DEFAULT_EXPANDED, ...settings.expanded };
   const reviewSummary = data.reviews?.ok ? data.reviews.summary.desc : "";
 
@@ -272,9 +341,9 @@ export function StorePanel({ appid, slot = "primary", fallback }: Props) {
     sections.push({
       id: "deck",
       title: "Steam Deck",
-      subtitle: data.deck?.ok ? data.deck.label : undefined,
+      subtitle: data.deck?.ok ? data.deck.label : pending ? "…" : undefined,
       defaultOpen: expanded.deck,
-      node: <DeckCompatDetails deck={data.deck} />,
+      node: pending ? <SectionLoading lines={2} /> : <DeckCompatDetails deck={data.deck} />,
     });
   if (sec.reviews)
     sections.push({
@@ -282,9 +351,13 @@ export function StorePanel({ appid, slot = "primary", fallback }: Props) {
       title: "Reviews",
       subtitle: data.reviews?.ok
         ? data.reviews.summary.total_reviews.toLocaleString()
-        : undefined,
+        : pending
+          ? "…"
+          : undefined,
       defaultOpen: expanded.reviews,
-      node: (
+      node: pending ? (
+        <SectionLoading lines={4} />
+      ) : (
         <ReviewsSection
           reviews={data.reviews}
           appid={fetchAppid ?? appid}
@@ -296,9 +369,9 @@ export function StorePanel({ appid, slot = "primary", fallback }: Props) {
     sections.push({
       id: "news",
       title: "Update history",
-      subtitle: data.news?.ok ? `${data.news.items.length}` : undefined,
+      subtitle: data.news?.ok ? `${data.news.items.length}` : pending ? "…" : undefined,
       defaultOpen: expanded.news,
-      node: <NewsSection news={data.news} />,
+      node: pending ? <SectionLoading lines={3} /> : <NewsSection news={data.news} />,
     });
 
   const header = (

--- a/src/earlyNav.ts
+++ b/src/earlyNav.ts
@@ -1,0 +1,144 @@
+// Early-navigation replay.
+//
+// The panel is injected into a page Steam already owns, so there is always a
+// window — however short — between the app page becoming interactive and our
+// host <div> existing. A D-pad Down (or a stick flick) inside that window moves
+// the cursor from the header/Play area straight past our slot to the tab strip,
+// and when the panel then lands the user has "skipped" a section they never saw.
+//
+// So we remember focus moves made on the app page while the panel is still
+// missing. When the host attaches, the injector asks whether the user crossed
+// our slot during that window; if so it replays the press by putting focus on
+// the panel's first stop — exactly where the press would have landed had the
+// panel been there.
+//
+// Only DOM focus is read (Valve's nav sets real focus on its active element, so
+// `focusin` mirrors gamepad navigation); nothing is intercepted or swallowed.
+
+interface Move {
+  from: HTMLElement | null;
+  to: HTMLElement | null;
+  at: number;
+}
+
+// How long after a page enter a crossing still counts as "the user pressed down
+// before the panel appeared". Long enough for a slow cold page, short enough
+// that a deliberate move to the tabs a beat later is never hijacked.
+const GRACE_MS = 2500;
+
+let armedAt = 0;
+let armedKey = "";
+let listening = false;
+let listeningDoc: Document | null = null;
+let lastFocused: HTMLElement | null = null;
+let moves: Move[] = [];
+
+function onFocusIn(e: Event): void {
+  const to = (e.target as HTMLElement) ?? null;
+  if (armedAt) {
+    moves.push({ from: lastFocused, to, at: Date.now() });
+    if (moves.length > 8) moves.shift();
+  }
+  lastFocused = to;
+}
+
+/**
+ * Start watching focus moves for a fresh app-page enter. `pageKey` identifies
+ * the page: Steam re-renders the route several times while a page settles, and
+ * re-arming on each of those would throw away the very press we are trying to
+ * remember, so a repeat of the same key is a no-op.
+ */
+export function armEarlyNav(doc: Document | null | undefined, pageKey: string): void {
+  try {
+    if (!doc) return;
+    if (pageKey === armedKey) return;
+    armedKey = pageKey;
+    if (!listening || listeningDoc !== doc) {
+      if (listeningDoc) listeningDoc.removeEventListener("focusin", onFocusIn, true);
+      doc.addEventListener("focusin", onFocusIn, true);
+      listening = true;
+      listeningDoc = doc;
+    }
+    armedAt = Date.now();
+    moves = [];
+    lastFocused = (doc.activeElement as HTMLElement) ?? null;
+  } catch {
+    /* focus history is an optimization — never let it break injection */
+  }
+}
+
+/** Stop recording (the panel is in place, or we left the app page). */
+export function disarmEarlyNav(): void {
+  armedAt = 0;
+  moves = [];
+}
+
+/**
+ * Forget which page we armed for, so returning to the SAME game later arms
+ * again. Called when the injector sees that no app page is on screen.
+ */
+export function resetEarlyNavPage(): void {
+  armedKey = "";
+  disarmEarlyNav();
+}
+
+/** Full teardown on plugin unload: drop the focus listener too. */
+export function stopEarlyNav(): void {
+  disarmEarlyNav();
+  try {
+    if (listeningDoc) listeningDoc.removeEventListener("focusin", onFocusIn, true);
+  } catch {
+    /* ignore */
+  }
+  listening = false;
+  listeningDoc = null;
+  lastFocused = null;
+  armedKey = "";
+}
+
+const isBefore = (el: HTMLElement, ref: HTMLElement): boolean => {
+  if (!el.isConnected || !ref.isConnected) return false;
+  const rel = ref.compareDocumentPosition(el);
+  // PRECEDING (2) and not contained by ref: strictly above our slot.
+  return !!(rel & Node.DOCUMENT_POSITION_PRECEDING) && !(rel & Node.DOCUMENT_POSITION_CONTAINS);
+};
+
+const isAfter = (el: HTMLElement, ref: HTMLElement): boolean => {
+  if (!el.isConnected || !ref.isConnected) return false;
+  const rel = ref.compareDocumentPosition(el);
+  // FOLLOWING (4) covers both a later sibling (the tab strip) and its contents.
+  return !!(rel & Node.DOCUMENT_POSITION_FOLLOWING);
+};
+
+/**
+ * Did the user navigate across our (not yet existing) slot during the grace
+ * window? Consumes the answer: it can only fire once per page enter.
+ */
+export function consumeSlotCrossing(host: HTMLElement | null): boolean {
+  try {
+    if (!host || !host.isConnected || !armedAt) return false;
+    if (Date.now() - armedAt > GRACE_MS) {
+      disarmEarlyNav();
+      return false;
+    }
+    const recent = moves.filter((m) => m.at >= armedAt && !!m.from && !!m.to);
+    const crossed = recent.some(
+      (m) =>
+        m.from !== m.to &&
+        !host.contains(m.from as HTMLElement) &&
+        !host.contains(m.to as HTMLElement) &&
+        isBefore(m.from as HTMLElement, host) &&
+        isAfter(m.to as HTMLElement, host)
+    );
+    // ...and the user is still down there. If they crossed the empty slot and
+    // then came back up, they are already where they wanted to be — pulling
+    // them into the panel would be the hijack this is meant to avoid.
+    const last = recent[recent.length - 1]?.to as HTMLElement | undefined;
+    const landedBelow = !!last && !host.contains(last) && isAfter(last, host);
+    disarmEarlyNav();
+    return crossed && landedBelow;
+  } catch {
+    disarmEarlyNav();
+    return false;
+  }
+}

--- a/src/focus.ts
+++ b/src/focus.ts
@@ -42,3 +42,29 @@ export const CENTER_ON_FOCUS = {
     return false; // let the native scroller take it
   },
 } as Record<string, unknown>;
+
+// Move gamepad focus to the first focus stop inside `root` (Valve's nav reacts
+// to real DOM focus, which is how decky-ui's own autoFocus works). Used when
+// the loading placeholder the user is standing on is replaced by real content,
+// and when replaying a D-pad press that landed before the panel existed — in
+// both cases dropping focus would bounce the page back to the top.
+export function focusFirstStop(root: HTMLElement | null | undefined): boolean {
+  try {
+    if (!root || !root.isConnected) return false;
+    const all = Array.from(
+      root.querySelectorAll<HTMLElement>('[tabindex]:not([tabindex="-1"])')
+    );
+    // Prefer a laid-out stop, but never give up just because the measurement is
+    // unavailable — an unfocusable panel is worse than an odd landing spot.
+    const visible = all.filter(
+      (el) => el.offsetParent !== null || (el.getClientRects?.().length ?? 0) > 0
+    );
+    const target =
+      visible[0] ?? all[0] ?? (root.hasAttribute("tabindex") ? root : null);
+    if (!target) return false;
+    target.focus();
+    return root.ownerDocument.activeElement === target;
+  } catch {
+    return false;
+  }
+}

--- a/src/hooks/useAppData.ts
+++ b/src/hooks/useAppData.ts
@@ -1,13 +1,21 @@
 import { useEffect, useState } from "react";
-import { getAll, getSettings } from "../api";
+import { getAll, getAppDetails, getSettings } from "../api";
 import { DEFAULT_EXPANDED } from "../types";
-import type { AppData, PluginSettings } from "../types";
+import type { AppData, AppDetails, PluginSettings } from "../types";
 import { resolveLanguage, resolveCountry } from "../lang";
 
 // Module-level caches survive the re-splicing of the panel into the app tree,
 // so navigating back to a game (or a re-render of renderFunc) never refetches.
 const dataCache = new Map<number, AppData>();
 const inflight = new Map<number, Promise<AppData>>();
+
+// First-paint cache: the appdetails-only result (hero, description, features).
+// It is requested alongside the full get_all so the panel can paint the moment
+// the single store-details request lands, instead of waiting for the slowest of
+// appdetails + reviews + news + deck. Superseded by dataCache the moment the
+// full result arrives.
+const coreCache = new Map<number, AppData>();
+const coreInflight = new Map<number, Promise<AppData | null>>();
 
 // Failures are cached too (with a short TTL): the panel remounts on every tab
 // switch (Steam's tab transition is keyed), and without a negative cache a game
@@ -25,6 +33,9 @@ const FAILURE_TTL_MS = 60_000;
 // a local file) uses a much shorter cap — if IT times out the backend is dead.
 const CALL_TIMEOUT_MS = 25_000;
 const SETTINGS_TIMEOUT_MS = 6_000;
+// The first-paint call is a single HTTP request behind a disk cache; if it has
+// not answered well before get_all would, there is nothing to gain from it.
+const CORE_TIMEOUT_MS = 20_000;
 export function withTimeout<T>(p: Promise<T>, what: string, ms = CALL_TIMEOUT_MS): Promise<T> {
   let timer: ReturnType<typeof setTimeout>;
   return Promise.race([
@@ -110,6 +121,8 @@ export function clearFrontendCache(): void {
   dataCache.clear();
   inflight.clear();
   failureCache.clear();
+  coreCache.clear();
+  coreInflight.clear();
   extraCacheClearers.forEach((fn) => {
     try {
       fn();
@@ -192,6 +205,73 @@ async function loadData(appid: number, settings: PluginSettings): Promise<AppDat
   return promise;
 }
 
+// A first-paint AppData: real store details, the other three sections marked
+// pending so StorePanel shows their loading placeholder rather than "no data".
+const PENDING_SECTION = { ok: false, error: "loading" };
+function corePaint(appid: number, d: AppDetails): AppData {
+  return {
+    ok: true,
+    appid,
+    appdetails: d,
+    reviews: PENDING_SECTION as unknown as AppData["reviews"],
+    news: PENDING_SECTION as unknown as AppData["news"],
+    deck: PENDING_SECTION as unknown as AppData["deck"],
+    partial: true,
+  };
+}
+
+// appdetails on its own, for the first paint. Failures resolve to null and are
+// simply ignored — get_all is the authority and reports the real error.
+function loadCore(appid: number, settings: PluginSettings): Promise<AppData | null> {
+  const cached = coreCache.get(appid) ?? dataCache.get(appid);
+  if (cached) return Promise.resolve(cached);
+
+  let promise = coreInflight.get(appid);
+  if (!promise) {
+    promise = withTimeout(
+      getAppDetails(appid, resolveLanguage(settings.language), resolveCountry(settings.country)),
+      "get_appdetails",
+      CORE_TIMEOUT_MS
+    )
+      .then((d) => {
+        if (!d || !d.ok) return null;
+        const paint = corePaint(appid, d);
+        lruSet(coreCache, appid, paint);
+        return paint;
+      })
+      .catch(() => null)
+      .finally(() => coreInflight.delete(appid));
+    coreInflight.set(appid, promise);
+  }
+  return promise;
+}
+
+/**
+ * Start the store fetch for a game BEFORE the panel mounts. The injector calls
+ * this the moment Steam renders the app-page route, so the round-trip overlaps
+ * the page transition and the panel's own DOM/portal work instead of starting
+ * after it. Purely speculative: results land in the same caches the panel reads,
+ * and every failure path is swallowed.
+ */
+export function prefetchAppData(appid: number): void {
+  if (!appid || appid <= 0) return;
+  if (dataCache.has(appid)) return;
+  void (async () => {
+    try {
+      const s = await loadSettings();
+      void loadCore(appid, s).catch(() => null);
+      void loadData(appid, s).catch(() => null);
+    } catch {
+      /* prefetch is best-effort */
+    }
+  })();
+}
+
+/** Read settings once at plugin start so they are never on the panel's path. */
+export function warmSettings(): void {
+  void loadSettings().catch(() => null);
+}
+
 export interface UseAppData {
   data: AppData | null;
   settings: PluginSettings;
@@ -208,7 +288,7 @@ export function getFetchInfo(): { startedAt: number; settledAt: number; note: st
 
 const hasFreshResult = (appid: number | null): boolean => {
   if (!appid) return false;
-  if (dataCache.has(appid)) return true;
+  if (dataCache.has(appid) || coreCache.has(appid)) return true;
   const f = failureCache.get(appid);
   return !!f && Date.now() - f.at < FAILURE_TTL_MS;
 };
@@ -216,9 +296,9 @@ const hasFreshResult = (appid: number | null): boolean => {
 // appid is null while the game is still being resolved to a store appid (or a
 // non-Steam game has no match) — no fetch happens in that case.
 export function useAppData(appid: number | null): UseAppData {
-  const [data, setData] = useState<AppData | null>(
-    appid ? dataCache.get(appid) ?? null : null
-  );
+  const cachedFor = (id: number | null): AppData | null =>
+    id ? dataCache.get(id) ?? coreCache.get(id) ?? null : null;
+  const [data, setData] = useState<AppData | null>(cachedFor(appid));
   const [settings, setSettings] = useState<PluginSettings>(
     settingsCache ?? DEFAULT_SETTINGS
   );
@@ -232,7 +312,7 @@ export function useAppData(appid: number | null): UseAppData {
   const [prevAppid, setPrevAppid] = useState<number | null>(appid);
   if (appid !== prevAppid) {
     setPrevAppid(appid);
-    setData(appid ? dataCache.get(appid) ?? null : null);
+    setData(cachedFor(appid));
     setError(null);
     setLoading(!hasFreshResult(appid));
   }
@@ -250,7 +330,7 @@ export function useAppData(appid: number | null): UseAppData {
     let cancelled = false;
 
     // Reset from cache on appid change (covers a reused panel instance).
-    setData(appid ? dataCache.get(appid) ?? null : null);
+    setData(cachedFor(appid));
     setError(null);
 
     // Null (still resolving) / non-positive ids won't have store data; skip the
@@ -268,15 +348,32 @@ export function useAppData(appid: number | null): UseAppData {
       try {
         const s = await loadSettings();
         if (!cancelled) setSettings(s);
+        // Two requests, one round trip apart at worst: whichever of the two
+        // lands first paints. The first-paint result is only adopted while the
+        // full one is still outstanding.
+        let full = false;
+        const core = loadCore(appid, s).then((paint) => {
+          if (cancelled || full || !paint) return;
+          setData(paint);
+          setLoading(false);
+        });
+        void core;
         const res = await loadData(appid, s);
+        full = true;
         if (cancelled) return;
         if (res && res.ok) {
           setData(res);
         } else {
           setError(res?.error ?? "unavailable");
+          // Keep a first paint that is already on screen, but stop the remaining
+          // sections from waiting on a result that will never arrive.
+          setData((d) => (d && d.partial ? { ...d, partial: false } : d));
         }
       } catch (e) {
-        if (!cancelled) setError(String(e));
+        if (!cancelled) {
+          setError(String(e));
+          setData((d) => (d && d.partial ? { ...d, partial: false } : d));
+        }
       } finally {
         if (!cancelled) setLoading(false);
       }

--- a/src/patchLibraryApp.tsx
+++ b/src/patchLibraryApp.tsx
@@ -6,6 +6,15 @@ import type { ReactElement } from "react";
 import { StorePanel } from "./components/StorePanel";
 import { captureNavFromElement, isCaptureLive, appidFromElement } from "./navBridge";
 import type { NavCapture } from "./navBridge";
+import { prefetchAppData, warmSettings } from "./hooks/useAppData";
+import { getGameIdentity } from "./identity";
+import {
+  armEarlyNav,
+  stopEarlyNav,
+  resetEarlyNavPage,
+  consumeSlotCrossing,
+} from "./earlyNav";
+import { focusFirstStop } from "./focus";
 import {
   setDiag,
   markInjectApply,
@@ -100,16 +109,20 @@ function stablePanel(appid: number): ReactElement {
   return p;
 }
 
-// A "resync now" signal (route render) fans out to the mounted host.
-const listeners = new Set<() => void>();
-function notify(): void {
+// A "resync now" signal (route render) fans out to the mounted host. A listener
+// reports whether it is SETTLED (panel attached to the visible page, or there is
+// no app page to attach to) so the retry burst below can stop early.
+const listeners = new Set<() => boolean>();
+function notify(): boolean {
+  let settled = true;
   listeners.forEach((l) => {
     try {
-      l();
+      if (!l()) settled = false;
     } catch {
-      /* ignore */
+      settled = false;
     }
   });
+  return settled;
 }
 
 // PLUGIN-COEXISTENCE (v0.18): NEVER run the resync fan-out synchronously from a
@@ -122,14 +135,73 @@ function notify(): void {
 // THEIR frame and Decky's ErrorBoundary blames them. Deferring to a fresh
 // macrotask guarantees sync() only ever mutates the DOM AFTER commit. Coalesced so
 // a burst of route renders collapses to a single resync.
-let notifyScheduled = false;
+//
+// LOAD TIME: a single deferred resync used to be the only prompt, so whenever the
+// app-details container was not yet laid out (offsetParent === null during the
+// page-enter transition — the common case) the panel had to wait for the 2s
+// heartbeat before it appeared. That is the whole "the panel shows up late, and a
+// D-pad press before it lands skips the section" problem. The route render now
+// starts a short RETRY BURST instead: densely at first, then tapering, stopping
+// the moment a listener reports it is settled. Every attempt still runs off the
+// render stack, so the coexistence guarantee above is unchanged.
+const RETRY_MS = [0, 16, 40, 80, 140, 220, 340, 500, 750, 1100, 1600];
+let burstTimers: ReturnType<typeof setTimeout>[] = [];
+let burstStartedAt = 0;
+
+function clearBurst(): void {
+  burstTimers.forEach(clearTimeout);
+  burstTimers = [];
+}
+
 function scheduleNotify(): void {
-  if (notifyScheduled) return;
-  notifyScheduled = true;
-  setTimeout(() => {
-    notifyScheduled = false;
-    notify();
-  }, 0);
+  // Coalesce the burst of route renders Steam emits while a page settles.
+  if (burstTimers.length && Date.now() - burstStartedAt < 120) return;
+  clearBurst();
+  burstStartedAt = Date.now();
+  for (const ms of RETRY_MS) {
+    burstTimers.push(
+      setTimeout(() => {
+        if (notify()) clearBurst();
+      }, ms)
+    );
+  }
+}
+
+// The appid of the page Steam is rendering, read from the router path. Used ONLY
+// to start the store fetch early (it overlaps the page transition and our own
+// injection work); the panel itself always uses the appid read from the visible
+// page's React fiber.
+function appidFromLocation(): number | null {
+  try {
+    const loc = window.location;
+    const m = /\/library\/app\/(\d+)/.exec(`${loc.pathname}${loc.search}${loc.hash}`);
+    if (!m) return null;
+    const n = Number(m[1]);
+    return Number.isFinite(n) && n > 0 ? n : null;
+  } catch {
+    return null;
+  }
+}
+
+let lastPrefetched = 0;
+let lastPrefetchedAt = 0;
+function prefetchForRoute(): void {
+  try {
+    const id = appidFromLocation();
+    if (!id) return;
+    // Steam re-renders the route several times while a page settles; only the
+    // first of those should start a fetch. The window also lets a later visit
+    // re-prime the caches (e.g. after "clear cached store data").
+    if (id === lastPrefetched && Date.now() - lastPrefetchedAt < 10_000) return;
+    lastPrefetched = id;
+    lastPrefetchedAt = Date.now();
+    // A non-Steam shortcut has to be matched to a store appid first (that
+    // happens in the panel), so there is nothing to prefetch for it here.
+    if (getGameIdentity(id).isShortcut) return;
+    prefetchAppData(id);
+  } catch {
+    /* prefetch is best-effort */
+  }
 }
 
 // ---------- the single injector: a Decky-owned global component -------------
@@ -157,10 +229,12 @@ function RestorePortalHost() {
       cap.current = null;
     };
 
-    const sync = () => {
-      if (disposed || unloaded) return;
+    // Returns TRUE when there is nothing left to wait for (panel attached to the
+    // visible page and bridged into its nav tree, or we are not on an app page).
+    const sync = (): boolean => {
+      if (disposed || unloaded) return true;
       const doc = probeRef.current?.ownerDocument ?? getPanelDoc();
-      if (!doc) return;
+      if (!doc) return false;
       const target = findVisibleContainer(doc);
       if (!target) {
         // Not on an app-details page -> tear our panel down and clear state.
@@ -169,12 +243,16 @@ function RestorePortalHost() {
           force();
         }
         if (currentAppid != null) currentAppid = null;
-        return;
+        // Left the app page: the next visit (even to the same game) arms afresh.
+        if (appidFromLocation() == null) resetEarlyNavPage();
+        // On an app page the container appears a beat after the route renders,
+        // so "not found yet" is only settled once we are off the route.
+        return appidFromLocation() == null;
       }
       const id = appidFromElement(target);
       if (id == null) {
         markInjectMiss("portal: appid not resolvable from visible container");
-        return;
+        return false;
       }
       currentAppid = id;
       // Re-render ONLY when something actually changed. The old unconditional
@@ -192,7 +270,7 @@ function RestorePortalHost() {
         const made = makeHostBeforeTarget(target);
         if (!made) {
           markInjectMiss("portal: could not insert host before container");
-          return;
+          return false;
         }
         host.current = made;
         appid.current = id;
@@ -225,11 +303,29 @@ function RestorePortalHost() {
         }
       }
       if (changed) force();
+      // Settled once the host is in the page AND its focus context is bridged —
+      // an unbridged panel is still worth retrying for (its Focusables would
+      // register at route level and be unreachable by the D-pad).
+      const settled = !!host.current?.isConnected && !!cap.current;
+      // The user may already have pressed Down (or flicked the stick) past the
+      // still-empty slot while we were attaching. Now that the panel is in the
+      // page AND reachable, replay that move into it — its loading placeholder
+      // is a focus stop — so the press scrolls into the section instead of
+      // skipping it. One-shot and grace-windowed (see earlyNav).
+      if (settled && consumeSlotCrossing(host.current)) {
+        const target = host.current;
+        setTimeout(() => {
+          if (!disposed && !unloaded && target?.isConnected) focusFirstStop(target);
+        }, 0);
+      }
+      return settled;
     };
 
     const l = () => sync();
     listeners.add(l);
     sync();
+    // Heartbeat for everything the route render can't tell us about (tab
+    // switches, page rebuilds). The fast path is the retry burst above.
     const iv = setInterval(sync, 2000);
     return () => {
       disposed = true;
@@ -261,6 +357,9 @@ function RestorePortalHost() {
 
 export function patchLibraryApp() {
   unloaded = false;
+  // Read the settings file once, now, so the first game page never waits on it
+  // before it can start fetching store data.
+  warmSettings();
   const rootCls = token(basicAppDetailsSectionStylerClasses, "AppDetailsRoot") ?? null;
   const adcCls = token(basicAppDetailsSectionStylerClasses, "AppDetailsContainer") ?? null;
   log(
@@ -289,6 +388,17 @@ export function patchLibraryApp() {
   return routerHook.addPatch(ROUTE, (tree: AnyEl) => {
     try {
       markRouteRender();
+      // Both are cheap and side-effect-free on Steam's tree: start the store
+      // fetch, and begin remembering focus moves so a D-pad press made before
+      // the panel lands can be replayed into it.
+      prefetchForRoute();
+      const routeId = appidFromLocation();
+      if (routeId != null) {
+        armEarlyNav(
+          getPanelDoc() ?? (typeof document !== "undefined" ? document : null),
+          String(routeId)
+        );
+      }
       scheduleNotify();
     } catch {
       /* ignore */
@@ -300,6 +410,8 @@ export function patchLibraryApp() {
 export function unpatchLibraryApp(patch: ReturnType<typeof patchLibraryApp>): void {
   unloaded = true;
   currentAppid = null;
+  clearBurst();
+  stopEarlyNav();
   notify(); // let the host detach + unmount its portal (Focusable RemoveChild runs cleanly)
   try {
     routerHook.removeGlobalComponent(GLOBAL_COMPONENT);

--- a/src/types.ts
+++ b/src/types.ts
@@ -155,6 +155,10 @@ export interface AppData {
   reviews: Reviews;
   news: News;
   deck: DeckCompat;
+  // First-paint result: appdetails is real, the other three sections are still
+  // in flight (see useAppData). Sections render a small loading placeholder
+  // instead of their "nothing here" state while this is set.
+  partial?: boolean;
 }
 
 export interface SectionToggles {


### PR DESCRIPTION
Targets **`beta`**, folding into its existing v0.19.0 alongside the Hasheous provider. Two things: get the panel (and its content) on screen much sooner, and make a Down press made before it lands scroll into the section instead of jumping past it.

## Load time

**Injection latency.** The route render used to schedule a single deferred re-sync. Whenever the app-details container wasn't laid out yet at that moment (`offsetParent === null` during the page-enter transition — the common case), the panel had to wait for the every-2-seconds heartbeat before it appeared. The route render now starts a short **retry burst** (0 → 1.6 s, tapering) that stops the moment the host is attached *and* bridged into the page's nav tree; the 2 s heartbeat is left to cover tab switches and page rebuilds. Every attempt still runs off the render stack via `setTimeout`, so the v0.18 co-plugin guarantee (never touch the shared subtree mid-render) is unchanged.

**Fetch start.** The store fetch now starts from the route render — appid read from the router path — so the round-trip overlaps the page transition and our own DOM/portal work instead of starting after the panel mounts. Settings are read once at plugin start (`warmSettings`) so `get_settings` is never on that path. Prefetch is speculative and fully swallowed: results land in the same caches the panel reads.

**Two-stage first paint.** `get_appdetails` is now requested alongside `get_all`, so description/media/details paint as soon as that single request lands rather than waiting for the slowest of appdetails + reviews + news + deck. The remaining sections render a shimmer (`SectionLoading`) and fill in behind it. The backend already de-duplicates in-flight requests per resource, so `get_all` reuses that same fetch rather than issuing a second one.

**Stale-while-revalidate on disk.** An entry past its TTL is now served immediately and refreshed in the background (7-day grace, positive results only — a stale failure is never served). Revisiting a game after the reviews/news TTL expired no longer means sitting through a full set of round-trips on the placeholder.

## Early D-pad press

- The loading / unmatched / unavailable placeholder is now a **real focus stop** (`PlaceholderStop`), so the D-pad scrolls into the panel instead of walking from Play straight to the tab strip.
- New `src/earlyNav.ts` records focus moves on the app page while the panel is missing (read-only: it listens to `focusin`, which mirrors Valve's nav; nothing is intercepted). If the user crossed the empty slot **and is still below it**, the press is replayed into the panel once it is attached and bridged — one-shot, 2.5 s grace, and not replayed if they moved back up.
- When content replaces the placeholder the user is standing on, focus moves to the panel's first stop rather than dropping out of the panel and scrolling the page back to the top.

## Merge with beta

This branch was cut from `main` and bumped to 0.19.0 independently, which collided with beta's own 0.19.0. Beta is merged in (`41ce2e0`) so both ship as one release. Resolutions:

- **`useAppData`** — beta re-keyed the data layer from a bare appid to a tagged `DataRef` (`{provider, id}`) with a string cache key. The first-paint layer is ported onto that model: `coreCache`/`coreInflight` are keyed by `refKey`, and `loadCore` is a no-op for non-Steam refs (a provider answers from one call, so there's no slower half to run ahead of). Hasheous data keeps its existing empty-state rendering — `pending` is only set on the Steam first-paint path.
- **`api.ts` / `StorePanel`** — additive on both sides; kept both.
- **`patchLibraryApp`** — prefetch now passes `{provider: "steam", id}` instead of a bare appid.
- **`CHANGELOG`** — folded into beta's v0.19.0 section, Hasheous first.
- **`plugin.json`** — beta had it left at 0.18.0 while `package.json` said 0.19.0; both now read 0.19.0.

## Testing

- `npm run build` and `tsc --noEmit` clean on the merged tree.
- Backend `_fetch` cache behavior covered by an ad-hoc asyncio harness: fresh hit, stale serve + background refresh (returns instantly, refreshed value on the next read, in-flight map drained), beyond-grace refetch, stale-negative never served, and concurrent cold callers sharing one HTTP request.
- `earlyNav` + `focusFirstStop` covered under jsdom: crossing detected, one-shot, no crossing when the user didn't move, a crossing the user undid is not replayed, repeated presses replay once, route re-render doesn't wipe a recorded press, a new page starts clean, teardown stops recording.
- Not yet exercised on-device; the on-hardware behaviors worth a look are the replay landing spot and the placeholder → content focus handoff. The Hasheous path from beta is likewise untested here beyond the typecheck.