### PR TITLE
v0.19.0 (beta): IGDB artwork for non-Steam / emulated games (opt-in, key-gated)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -2,10 +2,14 @@ name: Build EnhancedGV
 
 on:
   push:
-    branches: [main]
+    branches: [main, beta]
     tags: ["v*"]
   pull_request:
-    branches: [main]
+    # `beta` is a release line too (betas are cut from it and tagged
+    # vX.Y.Z-beta), so PRs into it need the same build gate as main —
+    # without it a beta-targeted PR reports NO checks at all, which reads
+    # like "nothing failed" when nothing actually ran.
+    branches: [main, beta]
   workflow_dispatch:
 
 permissions:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,25 @@
 # Changelog
 
+## v0.20.0
+
+- **Artwork for emulated / non-Steam games (opt-in, needs a free key).** The
+  non-Steam support added in 0.19.0 could only show a logo and a description.
+  Paste a **Hasheous API key** in Quick Access → EnhancedGV → *Non-Steam games*
+  and retro titles now get proper **cover art, screenshots, genres and
+  developers** from IGDB — so the media gallery works for a SNES ROM the same
+  way it does for a Steam game.
+  - Entirely optional. With no key, nothing changes: you still get the keyless
+    logo + description baseline.
+  - Steam games are untouched — this only affects games matched to a non-Steam
+    source.
+  - **Test artwork lookup** button reports, step by step, whether the key was
+    accepted and whether artwork came back, so a failure tells you *which* part
+    broke instead of just showing an empty gallery.
+  - Images load in display sizes rather than originals (a cover is ~21 KB
+    instead of ~2.7 MB), so the gallery doesn't stall on a handheld connection.
+  - The panel header now notes where non-Steam content came from
+    ("via Hasheous + IGDB").
+
 ## v0.19.0
 
 - **Metadata for emulated / non-Steam games (experimental, off by default).** When

--- a/README.md
+++ b/README.md
@@ -60,7 +60,9 @@ Access** panel.
 - **Backend** (`main.py`, Python stdlib only): fetches from Steam's store/web
   APIs (bypassing the browser's CORS restrictions), **normalizes and
   allowlist-sanitizes** the HTML/JSON, converts news BBCODE → safe HTML, resolves
-  non-Steam games to a store appid by title search, and caches responses to disk
+  non-Steam games to a store appid by title search, enriches non-Steam matches
+  with IGDB artwork when a Hasheous API key is set (metadata via the keyed
+  proxy; images from IGDB's public CDN in display sizes), and caches responses to disk
   (`DECKY_PLUGIN_RUNTIME_DIR`) with per-kind TTLs plus negative caching and
   in-flight de-duplication to stay well under Steam's rate limits. Expired
   entries are served **stale-while-revalidate** — the last known-good copy is

--- a/main.py
+++ b/main.py
@@ -17,6 +17,7 @@ import json
 import time
 import html
 import asyncio
+import functools
 import urllib.parse
 import urllib.request
 import urllib.error
@@ -41,7 +42,7 @@ CACHE_VERSION = "0.15.0-lang"
 TTL = {"appdetails": 86400, "deck": 86400, "reviews": 3600, "reviews_sum": 3600,
        "reviews_recent": 3600, "news": 3600,
        # Non-Steam / emulated metadata is essentially static — cache it a week.
-       "hasheous": 604800}
+       "hasheous": 604800, "igdb": 604800}
 # Negative results (fetch failed / success=false) are cached only briefly so a
 # transient network/SSL failure doesn't linger after it's resolved.
 NEGATIVE_TTL = 120
@@ -93,6 +94,27 @@ CLAN_IMAGE_BASE = "https://clan.akamai.steamstatic.com/images"
 #   -> DataObjects/Game/{id} (name, AIDescription, Logo, Tags, publisher, IGDB id)
 # The rich IGDB proxy (cover/screenshots/genres) is key-gated (a later, opt-in
 # phase); this baseline is entirely keyless and works with the feature toggled on.
+# --- IGDB enrichment (opt-in, needs a Hasheous CLIENT API key) --------------- #
+# Hasheous proxies IGDB at /MetadataProxy/IGDB/*. Verified against the live
+# OpenAPI spec and by probing the running service:
+#   * METADATA is key-gated: /MetadataProxy/IGDB/Game?Id=… answers 401 without an
+#     `X-Client-API-Key` header (securityScheme "Client API Key").
+#   * IMAGES are NOT key-gated: /MetadataProxy/IGDB/Image/{hash}.jpg answers 200
+#     with no key — but it serves the ORIGINAL (a cover measured at 2.7 MB), and
+#     it takes no size parameter (a t_cover_big-style path 404s).
+# So metadata goes through the proxy with the key, and image URLs point at IGDB's
+# own public CDN, which does serve sized renditions keylessly. Measured on the
+# same cover: t_thumb 3 KB / t_cover_big 21 KB / t_screenshot_med 40 KB /
+# t_1080p 163 KB, versus 2.7 MB from the proxy. On a Deck over wifi, with a
+# thumbnail strip of a dozen shots, that difference is the whole feature.
+IGDB_IMG_CDN = "https://images.igdb.com/igdb/image/upload"
+IGDB_SIZE_COVER = "t_cover_big"
+IGDB_SIZE_THUMB = "t_screenshot_med"
+IGDB_SIZE_FULL = "t_1080p"
+# Screenshot/artwork metadata is one request PER image id, so cap how many we
+# resolve: enough to fill the carousel, few enough to stay polite and quick.
+IGDB_MAX_SHOTS = 12
+
 HASHEOUS_BASE = "https://hasheous.org/api/v1"
 HASHEOUS_IMAGE = HASHEOUS_BASE + "/Images/"  # + {image_hash}
 # sha1("") — Hasheous stores this as a placeholder/empty Logo; never use it.
@@ -131,8 +153,11 @@ _SSL_CTX = _build_ssl_context()
 _SSL_UNVERIFIED = ssl._create_unverified_context()
 
 
-def _http_get_json(url: str) -> dict:
-    req = urllib.request.Request(url, headers={"User-Agent": USER_AGENT})
+def _http_get_json(url: str, headers: dict = None) -> dict:
+    hdrs = {"User-Agent": USER_AGENT}
+    if headers:
+        hdrs.update(headers)
+    req = urllib.request.Request(url, headers=hdrs)
     try:
         with urllib.request.urlopen(req, timeout=REQUEST_TIMEOUT, context=_SSL_CTX) as resp:
             raw = resp.read().decode("utf-8", "replace")
@@ -246,6 +271,42 @@ def _feature_non_steam() -> bool:
             return bool(json.load(fh).get("nonSteamSources", False))
     except Exception:
         return False
+
+
+def _igdb_key() -> str:
+    """The Hasheous CLIENT API key, or "" when enrichment is off. Read from the
+    settings file for the same reason as _feature_non_steam. NEVER logged."""
+    try:
+        with open(SETTINGS_FILE, "r", encoding="utf-8") as fh:
+            return str(json.load(fh).get("hasheousApiKey", "") or "").strip()
+    except Exception:
+        return ""
+
+
+def _igdb_img(image_hash: str, size: str) -> str:
+    """A sized IGDB CDN URL. Keyless and public (see the note above)."""
+    h = re.sub(r"[^A-Za-z0-9_-]", "", str(image_hash or ""))
+    return f"{IGDB_IMG_CDN}/{size}/{h}.jpg" if h else ""
+
+
+def _igdb_pick(obj, *names):
+    """Read the first present key from an IGDB proxy object.
+
+    The proxy is a C# service in front of IGDB's snake_case JSON, and the OpenAPI
+    spec types most nested objects as bare `object` — so the exact casing of a
+    field is not guaranteed by the contract. Rather than pin one spelling and
+    break on the other, try the plausible ones. Unverified against a live keyed
+    response (no key available here), so this stays deliberately forgiving.
+    """
+    if not isinstance(obj, dict):
+        return None
+    for n in names:
+        for cand in (n, n[:1].upper() + n[1:], n[:1].lower() + n[1:],
+                     n.replace("_", ""), n.replace("_", "").lower(),
+                     "".join(w[:1].upper() + w[1:] for w in n.split("_"))):
+            if cand in obj and obj[cand] not in (None, ""):
+                return obj[cand]
+    return None
 
 
 def _rec_to_result(rec: dict) -> dict:
@@ -978,10 +1039,20 @@ def _normalize_hasheous(obj: dict) -> dict:
             platform_name = sd[0].get("Platform") or ""
 
     website = None
+    igdb_id = 0
     for m in (obj.get("metadata") or []):
-        if m.get("source") == "IGDB" and m.get("status") == "Mapped" and m.get("link"):
-            website = m["link"]
-            break
+        if m.get("source") == "IGDB" and m.get("status") == "Mapped":
+            if m.get("link") and not website:
+                website = m["link"]
+            # `id` (== immutableId) is the IGDB game id — the handle the keyed
+            # MetadataProxy needs. Verified on a live DataObject: Super Metroid
+            # (Hasheous 6292) carries IGDB id 1103.
+            try:
+                igdb_id = int(m.get("id") or m.get("immutableId") or 0)
+            except Exception:
+                igdb_id = 0
+            if website and igdb_id:
+                break
 
     year = ""
     for sd in (obj.get("signatureDataObjects") or []):
@@ -1025,6 +1096,8 @@ def _normalize_hasheous(obj: dict) -> dict:
         "supported_languages_html": langs,
         "pc_requirements": None,
         "content_descriptor_notes": None,
+        # Handle for the opt-in IGDB enrichment pass (0 = unmapped).
+        "igdb_id": igdb_id,
     }
 
 
@@ -1477,32 +1550,231 @@ class Plugin:
                                 "platform": (g.get("platform") or {}).get("name", "")}
         return {"ok": False, "error": "no resolvable rom hash"}
 
-    async def get_all_provider(self, provider, id, lang: str = "english",
-                               cc: str = "us"):
-        """Non-Steam metadata aggregate — same AppData shape as get_all, with
-        reviews/news/deck = {ok:False} (they hide cleanly in the panel)."""
-        if provider != "hasheous":
-            return {"ok": False, "error": f"unknown provider: {provider}"}
+    # --- IGDB enrichment (opt-in; needs a Hasheous client API key) --------- #
+    async def _igdb_get(self, path: str, params: dict, key: str):
+        """One keyed GET against the IGDB metadata proxy."""
+        url = f"{HASHEOUS_BASE}/MetadataProxy/IGDB/{path}?" + urllib.parse.urlencode(params)
+        loop = asyncio.get_running_loop()
+        return await loop.run_in_executor(
+            None, functools.partial(_http_get_json, url, {"X-Client-API-Key": key})
+        )
+
+    async def _igdb_image_hash(self, kind: str, image_id, key: str):
+        """Resolve one Cover/Screenshot/Artwork id to its IGDB image hash."""
         try:
-            gid = int(id)
+            obj = await self._igdb_get(kind, {"Id": int(image_id)}, key)
         except Exception:
-            return {"ok": False, "error": "invalid provider id"}
-        url = f"{HASHEOUS_BASE}/DataObjects/Game/{gid}"
+            return None
+        return _igdb_pick(obj, "image_id", "imageId", "hash")
 
-        def norm(raw):
-            if not isinstance(raw, dict) or not raw.get("name"):
-                return {"ok": False, "error": "no hasheous data"}
-            return _normalize_hasheous(raw)
+    async def _igdb_names(self, kind: str, ids, key: str, limit: int = 12):
+        """Resolve a list of ids (Genre, Company, …) to their display names."""
+        out = []
+        for chunk in [list(ids)[:limit]]:
+            got = await asyncio.gather(
+                *[self._igdb_get(kind, {"Id": int(i)}, key) for i in chunk],
+                return_exceptions=True,
+            )
+            for o in got:
+                if isinstance(o, BaseException):
+                    continue
+                n = _igdb_pick(o, "name")
+                if n:
+                    out.append(str(n))
+        return out
 
-        appdetails = await self._fetch("hasheous", str(gid), url, norm)
-        return {
-            "ok": True,
-            "appid": gid,
-            "appdetails": appdetails,
-            "reviews": {"ok": False, "error": "reviews are Steam-only"},
-            "news": {"ok": False, "error": "update history is Steam-only"},
-            "deck": {"ok": False, "error": "not a Steam app"},
-        }
+    async def _igdb_delta(self, igdb_id: int, key: str) -> dict:
+        """Fetch the IGDB-derived fields for a game. CACHED ON ITS OWN — never
+        cache the merged result: the merge depends on what the Hasheous baseline
+        already had, so a cached merge made against one baseline would be served
+        over a different one. Returns {} on any failure."""
+        cached = _read_cache_entry("igdb", str(igdb_id))[0]
+        if isinstance(cached, dict):
+            return cached
+
+        try:
+            game = await self._igdb_get("Game", {"Id": int(igdb_id)}, key)
+        except urllib.error.HTTPError as exc:
+            # 401/403 = missing/rejected key. Logged without the key itself.
+            decky.logger.error(f"igdb: HTTP {exc.code} for game {igdb_id}")
+            return {}
+        except Exception as exc:
+            decky.logger.error(f"igdb: game {igdb_id} failed: {exc}")
+            return {}
+        if not isinstance(game, dict):
+            return {}
+
+        delta = {}
+
+        cover_id = _igdb_pick(game, "cover")
+        if cover_id:
+            h = await self._igdb_image_hash("Cover", cover_id, key)
+            if h:
+                delta["header_image"] = _igdb_img(h, IGDB_SIZE_COVER)
+
+        # Screenshots (+ artworks as filler) — the media hero is the whole point
+        # of this phase; the keyless baseline has none.
+        pairs = ([("Screenshot", i) for i in (_igdb_pick(game, "screenshots") or [])] +
+                 [("Artwork", i) for i in (_igdb_pick(game, "artworks") or [])])[:IGDB_MAX_SHOTS]
+        shots = []
+        if pairs:
+            hashes = await asyncio.gather(
+                *[self._igdb_image_hash(k, i, key) for k, i in pairs],
+                return_exceptions=True,
+            )
+            for (_kind, ident), h in zip(pairs, hashes):
+                if isinstance(h, BaseException) or not h:
+                    continue
+                shots.append({"id": int(ident),
+                              "thumb": _igdb_img(h, IGDB_SIZE_THUMB),
+                              "full": _igdb_img(h, IGDB_SIZE_FULL)})
+        if shots:
+            delta["screenshots"] = shots
+
+        gids = list(_igdb_pick(game, "genres") or [])
+        if gids:
+            names = await self._igdb_names("Genre", gids, key)
+            if names:
+                delta["genres"] = [{"id": n, "description": n} for n in names]
+
+        ic_ids = list(_igdb_pick(game, "involved_companies") or [])
+        if ic_ids:
+            devs, pubs = [], []
+            got = await asyncio.gather(
+                *[self._igdb_get("InvolvedCompany", {"Id": int(i)}, key)
+                  for i in ic_ids[:8]],
+                return_exceptions=True,
+            )
+            for ic in got:
+                if isinstance(ic, BaseException) or not isinstance(ic, dict):
+                    continue
+                cid = _igdb_pick(ic, "company")
+                if not cid:
+                    continue
+                try:
+                    comp = await self._igdb_get("Company", {"Id": int(cid)}, key)
+                except Exception:
+                    continue
+                nm = _igdb_pick(comp, "name")
+                if not nm:
+                    continue
+                if _igdb_pick(ic, "developer"):
+                    devs.append(str(nm))
+                elif _igdb_pick(ic, "publisher"):
+                    pubs.append(str(nm))
+            if devs:
+                delta["developers"] = devs
+            if pubs:
+                delta["publishers"] = pubs
+
+        summary = _igdb_pick(game, "summary")
+        if summary:
+            delta["summary_html"] = _sanitize_html(
+                "<p>" + html.escape(str(summary), quote=False).replace("\n", "<br>") + "</p>")
+            delta["summary_text"] = re.sub(r"\s+", " ", str(summary)).strip()[:320]
+
+        url_ = _igdb_pick(game, "url")
+        if url_:
+            delta["website"] = _safe_url(url_)
+
+        if delta:
+            _write_cache("igdb", str(igdb_id), delta)
+        return delta
+
+    async def _igdb_enrich(self, igdb_id: int, base: dict) -> dict:
+        """Layer IGDB artwork/details onto a normalized Hasheous AppDetails.
+
+        Best-effort throughout: a bad key, a rate limit or an unexpected shape
+        degrades to the keyless baseline rather than blanking the panel. Hasheous
+        data WINS wherever it has some — IGDB only fills what was empty. The one
+        exception is `screenshots`, which the baseline can never populate.
+        """
+        key = _igdb_key()
+        if not key or not igdb_id:
+            return base
+        delta = await self._igdb_delta(int(igdb_id), key)
+        if not delta:
+            return base
+
+        out = dict(base)
+        if delta.get("screenshots"):
+            out["screenshots"] = delta["screenshots"]
+        for field in ("header_image", "website", "developers", "publishers"):
+            if delta.get(field) and not out.get(field):
+                out[field] = delta[field]
+        # Genres: the baseline's are Hasheous tag soup, so prefer IGDB's when it
+        # has any — this is a quality upgrade, not a gap-fill.
+        if delta.get("genres"):
+            out["genres"] = delta["genres"]
+        if delta.get("summary_html") and not (base.get("about_html") or "").strip():
+            out["about_html"] = delta["summary_html"]
+            if not (base.get("short_description") or "").strip():
+                out["short_description"] = delta.get("summary_text", "")
+        out["igdb_enriched"] = True
+        return out
+
+    async def test_igdb(self, game_appid=0):
+        """Per-step IGDB probe for the QAM, so a beta tester can see exactly
+        where enrichment stops instead of just 'no artwork appeared'. Never
+        returns the key itself — only whether one is set and how long it is."""
+        key = _igdb_key()
+        steps = []
+
+        def step(name, ok, detail=""):
+            steps.append({"name": name, "ok": bool(ok), "detail": str(detail)[:200]})
+
+        step("Non-Steam sources enabled", _feature_non_steam(),
+             "on" if _feature_non_steam() else "turn it on above")
+        step("API key present", bool(key), f"{len(key)} chars" if key else "no key saved")
+        if not key:
+            return {"ok": False, "steps": steps, "error": "no API key"}
+
+        # Which game? The one on screen if it resolves to Hasheous, else a known
+        # public mapping (Super Metroid) so the key itself can still be tested.
+        igdb_id, label = 0, ""
+        try:
+            rec = _read_matches().get(str(int(game_appid or 0)))
+        except Exception:
+            rec = None
+        if isinstance(rec, dict) and rec.get("provider") == "hasheous":
+            try:
+                raw = await self._fetch(
+                    "hasheous", str(rec["provider_id"]),
+                    f"{HASHEOUS_BASE}/DataObjects/Game/{int(rec['provider_id'])}",
+                    lambda r: _normalize_hasheous(r) if isinstance(r, dict) and r.get("name")
+                    else {"ok": False, "error": "no hasheous data"})
+                igdb_id = int((raw or {}).get("igdb_id") or 0)
+                label = (raw or {}).get("name") or ""
+            except Exception as exc:
+                step("Look up this game on Hasheous", False, str(exc))
+        if igdb_id:
+            step("This game maps to IGDB", True, f"{label} -> IGDB {igdb_id}")
+        else:
+            igdb_id, label = 1103, "Super Metroid (fallback probe)"
+            step("This game maps to IGDB", False,
+                 "no IGDB mapping for this game; testing the key against a known title")
+
+        try:
+            game = await self._igdb_get("Game", {"Id": igdb_id}, key)
+            step("IGDB metadata (key accepted)", isinstance(game, dict),
+                 _igdb_pick(game, "name") or "no name field")
+        except urllib.error.HTTPError as exc:
+            step("IGDB metadata (key accepted)", False,
+                 f"HTTP {exc.code}" + (" — key rejected" if exc.code in (401, 403) else ""))
+            return {"ok": False, "steps": steps, "error": f"HTTP {exc.code}"}
+        except Exception as exc:
+            step("IGDB metadata (key accepted)", False, str(exc))
+            return {"ok": False, "steps": steps, "error": str(exc)}
+
+        shots = list(_igdb_pick(game, "screenshots") or [])
+        step("Screenshots listed", bool(shots), f"{len(shots)} found")
+        sample = ""
+        if shots:
+            h = await self._igdb_image_hash("Screenshot", shots[0], key)
+            sample = _igdb_img(h, IGDB_SIZE_THUMB) if h else ""
+            step("Image address resolved", bool(sample), sample or "no image id on the object")
+        return {"ok": True, "steps": steps, "igdb_id": igdb_id,
+                "name": label, "sample_image": sample}
 
     async def resolve_game(self, game_appid, is_shortcut: bool = False,
                            title: str = "", lang: str = "english", cc: str = "us",
@@ -1702,6 +1974,11 @@ class Plugin:
             # (Hasheous). OFF by default: when off, resolve_game does Steam
             # title-search only and non-Steam misses stay "unmatched".
             "nonSteamSources": False,
+            # Hasheous CLIENT API key. Empty = the keyless baseline (logo +
+            # description only). With a key, non-Steam games are enriched from
+            # IGDB (cover, screenshots, genres, developers). Stored locally in
+            # the plugin's settings file and sent ONLY to hasheous.org.
+            "hasheousApiKey": "",
         }
         _sub = ("sections", "expanded")  # merged as sub-dicts, not replaced
         try:

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "enhancedgv",
-  "version": "0.19.0",
+  "version": "0.20.0",
   "description": "Decky plugin that shows Steam store content (media, description, reviews, Deck compatibility, update history) on the library game page.",
   "type": "module",
   "scripts": {

--- a/plugin.json
+++ b/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "EnhancedGV",
   "author": "Featherwolf",
-  "version": "0.19.0",
+  "version": "0.20.0",
   "flags": [],
   "api_version": 1,
   "publish": {

--- a/src/api.ts
+++ b/src/api.ts
@@ -108,6 +108,22 @@ export interface BackendInfo {
 }
 export const getBackendInfo = callable<[], BackendInfo>("get_backend_info");
 
+export interface IgdbStep {
+  name: string;
+  ok: boolean;
+  detail: string;
+}
+export interface IgdbTest {
+  ok: boolean;
+  error?: string;
+  steps: IgdbStep[];
+  igdb_id?: number;
+  name?: string;
+  sample_image?: string;
+}
+// Per-step probe of the IGDB enrichment path. Never returns the key itself.
+export const testIgdb = callable<[game_appid: number], IgdbTest>("test_igdb");
+
 export interface VideoProbe {
   url: string;
   status: number;

--- a/src/components/QuickAccessSettings.tsx
+++ b/src/components/QuickAccessSettings.tsx
@@ -19,12 +19,13 @@ import {
   testVideo,
   getBackendInfo,
   resolveGame,
+  testIgdb,
   lookupStoreApp,
   setMatch,
   clearMatch,
   blankMatch,
 } from "../api";
-import type { VideoProbe, BackendInfo, ResolveResult } from "../api";
+import type { VideoProbe, BackendInfo, ResolveResult, IgdbStep } from "../api";
 import type { UpdateInfo } from "../types";
 import { getGameIdentity } from "../identity";
 import { providerLabel } from "../providers";
@@ -230,6 +231,108 @@ function StoreSourceSection({ appid, lang, cc }: { appid: number; lang: string; 
   );
 }
 
+// Artwork upgrade for non-Steam games: paste a Hasheous CLIENT API key and the
+// backend layers IGDB covers/screenshots/genres/developers over the keyless
+// baseline. The key lives in the plugin's local settings file and is sent only
+// to hasheous.org — the test below never echoes it back.
+function IgdbKeyRow() {
+  const [key, setKey] = useState<string>("");
+  const [saved, setSaved] = useState<boolean>(false);
+  const [busy, setBusy] = useState(false);
+  const [steps, setSteps] = useState<IgdbStep[] | null>(null);
+  const [note, setNote] = useState<string>("");
+
+  useEffect(() => {
+    let alive = true;
+    getSettings()
+      .then((s) => {
+        if (!alive) return;
+        setSaved(!!(s as PluginSettings).hasheousApiKey);
+      })
+      .catch(() => undefined);
+    return () => {
+      alive = false;
+    };
+  }, []);
+
+  const save = async (value: string) => {
+    try {
+      const cur = await getSettings();
+      const next = { ...(cur as PluginSettings), hasheousApiKey: value };
+      await setSettings(next);
+      primeSettings(next);
+      setSaved(!!value);
+      setNote(value ? "Key saved." : "Key cleared — back to the keyless baseline.");
+      // Cached non-Steam payloads were built without artwork; drop them so the
+      // next visit refetches with the key in play.
+      await clearCache().catch(() => undefined);
+      clearFrontendCache();
+    } catch (e) {
+      setNote(`Could not save: ${String(e)}`);
+    }
+  };
+
+  const runTest = async () => {
+    setBusy(true);
+    setSteps(null);
+    setNote("");
+    try {
+      const res = await testIgdb(getCurrentAppid() ?? 0);
+      setSteps(res.steps ?? []);
+      if (!res.ok && res.error) setNote(res.error);
+    } catch (e) {
+      setNote(String(e));
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  return (
+    <>
+      <PanelSectionRow>
+        <TextField
+          label="Hasheous API key (optional)"
+          description={
+            saved
+              ? "A key is saved. With one, retro games get IGDB covers, screenshots, genres and developers instead of just a logo and description."
+              : "Without a key you get the keyless baseline: logo + description. Paste a Hasheous client API key to add IGDB covers and screenshots."
+          }
+          value={key}
+          bIsPassword
+          onChange={(e: { target: { value: string } }) => setKey(e.target.value)}
+        />
+      </PanelSectionRow>
+      <PanelSectionRow>
+        <ButtonItem layout="below" onClick={() => save(key.trim())} disabled={!key.trim()}>
+          Save key
+        </ButtonItem>
+      </PanelSectionRow>
+      {saved && (
+        <PanelSectionRow>
+          <ButtonItem
+            layout="below"
+            onClick={() => {
+              setKey("");
+              void save("");
+            }}
+          >
+            Remove key
+          </ButtonItem>
+        </PanelSectionRow>
+      )}
+      <PanelSectionRow>
+        <ButtonItem layout="below" onClick={runTest} disabled={busy}>
+          {busy ? "Testing…" : "Test artwork lookup"}
+        </ButtonItem>
+      </PanelSectionRow>
+      {steps?.map((st) => (
+        <DiagRow key={st.name} label={st.name} value={`${st.ok ? "✔" : "✖"} ${st.detail}`} />
+      ))}
+      {!!note && <DiagRow label="Result" value={note} />}
+    </>
+  );
+}
+
 export function QuickAccessSettings() {
   const [settings, setLocal] = useState<PluginSettings>(DEFAULTS);
   const [diag, setDiag] = useState<DiagState>(getDiag());
@@ -399,6 +502,7 @@ export function QuickAccessSettings() {
             onChange={toggleNonSteam}
           />
         </PanelSectionRow>
+        {!!settings.nonSteamSources && <IgdbKeyRow />}
       </PanelSection>
 
       <PanelSection title="Sections shown on the game page">

--- a/src/components/StorePanel.tsx
+++ b/src/components/StorePanel.tsx
@@ -3,7 +3,7 @@ import type { CSSProperties, ReactNode } from "react";
 import { Focusable } from "@decky/ui";
 import { useAppData } from "../hooks/useAppData";
 import { useResolvedGame } from "../hooks/useResolvedGame";
-import { steamAppidOf } from "../providers";
+import { steamAppidOf, providerLabel } from "../providers";
 import { CENTER_ON_FOCUS, FOCUS_SCROLL_MARGIN, focusFirstStop } from "../focus";
 import {
   setDiag,
@@ -318,6 +318,14 @@ export function StorePanel({ appid, slot = "primary", fallback }: Props) {
   // sections show a shimmer rather than their empty state, and their subtitle
   // (review count, news count, Deck rating) fills in when the data lands.
   const pending = !!data.partial;
+  // Non-Steam content is worth attributing: the panel otherwise looks like a
+  // Steam store page, and which database supplied it changes what to expect
+  // (no reviews, no Deck rating, and artwork only when IGDB enrichment ran).
+  const provider = fetchRef?.provider ?? "steam";
+  const sourceNote =
+    provider === "steam"
+      ? ""
+      : `via ${providerLabel(provider)}${d.igdb_enriched ? " + IGDB" : ""}`;
   const expanded = { ...DEFAULT_EXPANDED, ...settings.expanded };
   const reviewSummary = data.reviews?.ok ? data.reviews.summary.desc : "";
 
@@ -384,6 +392,9 @@ export function StorePanel({ appid, slot = "primary", fallback }: Props) {
       <div style={{ display: "flex", alignItems: "center", gap: 10, flexWrap: "wrap" }}>
         {reviewSummary && (
           <span style={{ fontSize: 12.5, opacity: 0.85 }}>{reviewSummary}</span>
+        )}
+        {sourceNote && (
+          <span style={{ fontSize: 12, opacity: 0.6 }}>{sourceNote}</span>
         )}
         {data.deck?.ok && <DeckCompatBadge deck={data.deck} />}
       </div>

--- a/src/types.ts
+++ b/src/types.ts
@@ -66,6 +66,9 @@ export interface AppDetails {
   recommendations_total: number | null;
   achievements_total: number | null;
   supported_languages_html: string;
+  // Set by the backend when the IGDB pass added artwork/details on top of the
+  // keyless Hasheous baseline (drives the source note in the panel).
+  igdb_enriched?: boolean;
   pc_requirements: Requirements | null;
   content_descriptor_notes: string | null;
 }
@@ -197,6 +200,9 @@ export interface PluginSettings {
   language: string;
   country: string;
   beta?: boolean; // opt in to pre-release update checks
+  // Hasheous CLIENT API key. Empty = keyless baseline (logo + description);
+  // set = IGDB artwork/details for non-Steam games. Stored locally only.
+  hasheousApiKey?: string;
   // Opt in to pulling metadata for non-Steam / emulated games from external
   // sources (Hasheous). OFF by default — when off, non-Steam games behave exactly
   // as before (Steam title-search only, then "unmatched").


### PR DESCRIPTION
Phase 2 of non-Steam metadata, for private-beta testing before it rolls into the mainline release. The keyless baseline could only show a logo and a description; with a Hasheous client API key this adds **cover art, screenshots, genres and developers** from IGDB, so the media gallery works for a SNES ROM the way it does for a Steam game.

> **Version note:** this shipped under 0.20.0 initially, which skipped a number — the repo's convention is that the `beta` branch carries the version of the release it becomes, and v0.19.0 was never published (latest release is v0.18.0). Corrected to **0.19.0** in `b561a44`; the IGDB entry is folded into the v0.19.0 changelog section alongside the Hasheous entry.

## What I verified against the live service first

I probed hasheous.org's OpenAPI spec and the running API before writing anything, because the auth and image story determines the whole design:

| Finding | Consequence |
|---|---|
| `/MetadataProxy/IGDB/Game` returns **401** without `X-Client-API-Key` | Metadata calls carry the key |
| `/MetadataProxy/IGDB/Image/{hash}.jpg` returns **200 keyless** | No proxying needed for `<img>` — which matters, since an `<img src>` can't send a header |
| …but it serves the **original** (a cover measured at **2.7 MB**) and takes no size parameter (`t_cover_big/…` 404s) | Unusable as-is on a handheld |
| IGDB's own CDN serves sized renditions keylessly — same cover: `t_thumb` 3 KB, `t_cover_big` 21 KB, `t_screenshot_med` 40 KB, `t_1080p` 163 KB | **Image URLs point at the CDN**; 21 KB instead of 2.7 MB per cover |
| The IGDB id is `metadata[].id` (== `immutableId`) where `source == "IGDB"` | Confirmed live: Hasheous `6292` (Super Metroid) → IGDB `1103` |

## Design decisions worth review

- **The cache holds the IGDB delta, not the merged result.** My first pass cached the merge and a test caught it serving a payload built against one Hasheous baseline over a different one. The delta is cached; the merge happens fresh each time.
- **Hasheous wins where it has data**; IGDB fills gaps. Two deliberate exceptions: screenshots (the baseline can never have any) and genres (IGDB's real names beat Hasheous tag soup).
- **Everything degrades to the baseline.** A rejected key, a rate limit or an unexpected shape returns the keyless result rather than blanking the panel.
- **Tolerant field reading.** The OpenAPI spec types the nested IGDB objects as bare `object`, so field casing isn't guaranteed by the contract; the reader accepts PascalCase and snake_case.
- **Videos are skipped.** IGDB `GameVideo` returns a `VideoId` (a YouTube id), and the media hero plays direct video URLs — trailers stay Steam-only.

## Beta testing

`Test artwork lookup` in Quick Access runs a per-step probe (`test_igdb`) so a failure names the step — feature enabled → key present → game maps to IGDB → key accepted → screenshots listed → image address resolved. If the game on screen has no IGDB mapping it falls back to a known-good title so the key itself can still be validated. **The key is never echoed back** — the diagnostic reports only whether one is set and its length, and there's a test asserting that.

Saving or clearing a key drops the cached non-Steam payloads so the next visit refetches.

## Testing done

- `tsc --noEmit` and `npm run build` clean.
- IGDB harness: enrichment maps cover/shots/genres/companies/summary; delta is cached; existing Hasheous fields aren't overwritten; a 401 degrades to the baseline; no key issues no requests; the diagnostic doesn't leak the key.
- Pre-existing cache and `earlyNav` suites still pass.

## Not verified — check on device

- **No live keyed response was available**, so the IGDB proxy's exact JSON field casing is inferred from the OpenAPI schema. The tolerant reader is the mitigation, and `test_igdb` will say plainly if it's wrong.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JWGu2oG8Q4XtgVyBbuqFdm