### PR TITLE
Document the Hasheous client API key — and that it is not self-serve

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,11 +18,16 @@
   - This is the keyless baseline (title, description, genres, developer/publisher,
     platform, logo).
 - **Optional artwork upgrade for those games (needs a free key).** The keyless
-  baseline above shows a logo and a description. Paste a **Hasheous API key** in
-  Quick Access → EnhancedGV → *Non-Steam games* and retro titles also get proper
-  **cover art, screenshots, genres and developers** from IGDB — so the media
+  baseline above shows a logo and a description. Paste a **Hasheous client API
+  key** in Quick Access → EnhancedGV → *Non-Steam games* and retro titles also
+  get proper **cover art, screenshots, genres and developers** from IGDB — so the media
   gallery works for a SNES ROM the same way it does for a Steam game.
   - Entirely optional; with no key you get the keyless baseline unchanged.
+  - **Setting it up:** register at hasheous.org, create an app, and mint a *Client
+    API Key* against it — the step-by-step is in the README under *Setup & tips →
+    Metadata & artwork for emulated / non-Steam games*. Note this is **not** the
+    *Submission API Key* on your Hasheous profile page; that one is for ROM
+    managers and the metadata proxy rejects it with HTTP 401.
   - Steam games are untouched — this only affects games matched to a non-Steam
     source.
   - **Test artwork lookup** reports, step by step, whether the key was accepted

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,26 @@
 
 ## v0.19.0
 
+### Testing non-Steam / emulated game metadata
+
+Turn on **Quick Access → EnhancedGV → Non-Steam games (experimental)**, then open a
+ROM that was added to your library as its own shortcut. You should get a title,
+description, genres, developer/publisher, platform and a logo, sourced from
+**Hasheous**. That is the whole feature for now, and it needs no account and no key.
+
+Cover art and screenshots come from IGDB through Hasheous' *keyed* proxy, and those
+client API keys are **not self-serve**: Hasheous issues them per registered
+application, and creating an application is restricted to its admins and moderators
+— on a normal account the **New** button silently does nothing. Only three
+applications exist service-wide, all official integrations. So **leave the key field
+empty** unless you already hold a client API key. If you do have one, note it is not
+the *Submission API Key* from your Hasheous profile; that is a different key type and
+the proxy rejects it with `HTTP 401`.
+
+**Test artwork lookup** (same panel) reports each stage separately if you want to see
+where things stop.
+
+
 - **Metadata for emulated / non-Steam games (experimental, off by default).** When
   a non-Steam game has no Steam store page, EnhancedGV can now pull a description,
   details and artwork from **Hasheous** — a free, keyless community game database.
@@ -17,7 +37,7 @@
   - You can still override any match by hand (Quick Access → *Store data source*).
   - This is the keyless baseline (title, description, genres, developer/publisher,
     platform, logo).
-- **Optional artwork upgrade for those games (needs a free key).** The keyless
+- **Optional artwork upgrade for those games (needs a key you probably can't get yet).** The keyless
   baseline above shows a logo and a description. Paste a **Hasheous client API
   key** in Quick Access → EnhancedGV → *Non-Steam games* and retro titles also
   get proper **cover art, screenshots, genres and developers** from IGDB — so the media

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,11 +23,14 @@
   get proper **cover art, screenshots, genres and developers** from IGDB — so the media
   gallery works for a SNES ROM the same way it does for a Steam game.
   - Entirely optional; with no key you get the keyless baseline unchanged.
-  - **Setting it up:** register at hasheous.org, create an app, and mint a *Client
-    API Key* against it — the step-by-step is in the README under *Setup & tips →
-    Metadata & artwork for emulated / non-Steam games*. Note this is **not** the
-    *Submission API Key* on your Hasheous profile page; that one is for ROM
-    managers and the metadata proxy rejects it with HTTP 401.
+  - **Getting a key is not self-serve yet.** Hasheous issues client API keys per
+    *registered application*, and creating an application is admin/moderator-only
+    — only three exist service-wide, all official integrations. Until EnhancedGV
+    is registered, most users stay on the keyless baseline. Details in the README
+    under *Setup & tips → Metadata & artwork for emulated / non-Steam games*.
+  - If you do have a key, note it is **not** the *Submission API Key* on your
+    Hasheous profile page; that is a different key type and the metadata proxy
+    rejects it with HTTP 401.
   - Steam games are untouched — this only affects games matched to a non-Steam
     source.
   - **Test artwork lookup** reports, step by step, whether the key was accepted

--- a/README.md
+++ b/README.md
@@ -184,23 +184,29 @@ genres and developers** from IGDB, add a free Hasheous **client API key** — IG
 metadata is served through Hasheous' keyed proxy, so requests without a key are
 rejected with `HTTP 401`. Images themselves are keyless.
 
-*Getting a client API key (about five minutes, free):*
+> ⚠️ **A client API key is not self-serve today.** Hasheous issues client API keys
+> *per registered application*, and creating an application is restricted to
+> Hasheous admins/moderators — on a normal account the **New** button on the Apps
+> page silently does nothing, because the request is refused server-side with no
+> message. At the time of writing only three applications exist on the whole
+> service (Gaseous, Hasheous Test Client and RomM), all of them official
+> integrations. So unless you already hold a key, **the keyless baseline is what
+> you get**, and the key field below is only useful if EnhancedGV is registered
+> with Hasheous or you have been issued a key another way.
+>
+> Tracking this: getting EnhancedGV registered as a Hasheous application is a
+> maintainer-side conversation with the Hasheous project, not something an
+> individual user can do.
 
-1. **Create a Hasheous account.** Go to <https://hasheous.org>, choose **Sign In**,
-   then **Register Account**, and confirm the verification email.
-2. **Register an app.** Open
-   <https://hasheous.org/index.html?page=dataobjects&type=app>, press **New**, and
-   give it any name you like (e.g. `EnhancedGV on my Deck`). The "app" is just the
-   thing your key is issued against.
-3. **Mint the key.** Open that app's page and find **Create Client API Key**. Enter
-   a name, leave **Expires** on **Never**, and press **Create**.
-4. **Copy it immediately.** The key is revealed once, under **Your Client API Key**.
-   If you lose it, create another — there's no way to re-read an existing one.
+*If you already have a client API key,* it is the one created under **Create Client
+API Key** on an application's page (revealed once, under *Your Client API Key*).
 
-> ⚠️ **Not the "Submission API Key."** Your profile page also shows a *Submission
-> API Key*, described as being "for your ROM manager tool". That one submits hashes
-> to Hasheous and is **rejected** by the metadata proxy. You want the **Client API
-> Key** created against an app, as above.
+> ⚠️ **It is not the "Submission API Key."** Your Hasheous profile page shows one of
+> those, described as being "for your ROM manager tool". That is a different key
+> type (`X-API-Key` rather than `X-Client-API-Key`), and the metadata proxy
+> **rejects** it with `HTTP 401`. Because IGDB *images* are un-keyed while IGDB
+> *metadata* is keyed, using the wrong key looks like "no artwork appeared" rather
+> than an error.
 
 *Entering it on the Deck:*
 

--- a/README.md
+++ b/README.md
@@ -171,6 +171,72 @@ while viewing the game:
 This works for regular Steam games too — you'll rarely need it, but you can point
 any game at a different store page the same way.
 
+
+**Metadata & artwork for emulated / non-Steam games**
+
+Games that have no Steam store page at all (SNES/PS1/etc. ROMs added as individual
+shortcuts) fall back to **Hasheous**, a free community game database. Turn on
+**Quick Access → EnhancedGV → Non-Steam games (experimental)**.
+
+Without a key this is the *keyless baseline*: title, description, genres,
+developer/publisher, platform and a logo. To also get **cover art, screenshots,
+genres and developers** from IGDB, add a free Hasheous **client API key** — IGDB
+metadata is served through Hasheous' keyed proxy, so requests without a key are
+rejected with `HTTP 401`. Images themselves are keyless.
+
+*Getting a client API key (about five minutes, free):*
+
+1. **Create a Hasheous account.** Go to <https://hasheous.org>, choose **Sign In**,
+   then **Register Account**, and confirm the verification email.
+2. **Register an app.** Open
+   <https://hasheous.org/index.html?page=dataobjects&type=app>, press **New**, and
+   give it any name you like (e.g. `EnhancedGV on my Deck`). The "app" is just the
+   thing your key is issued against.
+3. **Mint the key.** Open that app's page and find **Create Client API Key**. Enter
+   a name, leave **Expires** on **Never**, and press **Create**.
+4. **Copy it immediately.** The key is revealed once, under **Your Client API Key**.
+   If you lose it, create another — there's no way to re-read an existing one.
+
+> ⚠️ **Not the "Submission API Key."** Your profile page also shows a *Submission
+> API Key*, described as being "for your ROM manager tool". That one submits hashes
+> to Hasheous and is **rejected** by the metadata proxy. You want the **Client API
+> Key** created against an app, as above.
+
+*Entering it on the Deck:*
+
+1. **Quick Access → EnhancedGV → Non-Steam games (experimental)** — make sure it's on.
+2. Paste the key into **Hasheous API key (optional)** and press **Save key**. The
+   field is masked, and saving clears cached store data so games you've already
+   opened refetch with artwork.
+3. **Remove key** reverts to the keyless baseline at any time.
+
+*Checking that it worked:* open a retro game's page, then press **Test artwork
+lookup** in the same panel. It reports each stage separately, so a failure tells you
+which part broke:
+
+| Row | ✖ means |
+| --- | --- |
+| Non-Steam sources enabled | The feature toggle above is off. |
+| API key present | Nothing saved — paste the key and press **Save key**. |
+| This game maps to IGDB | Hasheous has no IGDB link for *this* title. Not fatal: the key is then tested against a known game, so the rows below still tell you if the key is good. |
+| IGDB metadata (key accepted) | `HTTP 401`/`403` = wrong or expired key (most often the Submission key). Anything else is a network or Hasheous-side error. |
+| Screenshots listed | The key works, but IGDB has no screenshots for that title. |
+| Image address resolved | Screenshots exist but the image id couldn't be read — worth reporting. |
+
+*Scope and limits:*
+
+- **Steam games are untouched.** This only affects games matched to a non-Steam
+  source; a game that genuinely exists on Steam always uses the Steam store page.
+- **No trailers.** IGDB supplies YouTube ids rather than playable video URLs, so the
+  video gallery stays Steam-only.
+- **Per-game shortcuts only.** A single emulator/frontend entry (one RetroDeck or
+  ES-DE shortcut covering your whole library) has no per-game page to attach to.
+- **Images are fetched in display sizes** (a cover is ~21 KB rather than ~2.7 MB),
+  so the gallery doesn't stall on a handheld connection.
+- **The key is stored locally** in the plugin's own settings file and is sent only
+  to hasheous.org. It is never included in diagnostics — **Test artwork lookup**
+  reports only whether a key is present and how long it is.
+
 ## Notes & limits
 
 - **Plays nicely with other plugins.** EnhancedGV never patches Steam's render

--- a/src/components/QuickAccessSettings.tsx
+++ b/src/components/QuickAccessSettings.tsx
@@ -291,11 +291,11 @@ function IgdbKeyRow() {
     <>
       <PanelSectionRow>
         <TextField
-          label="Hasheous API key (optional)"
+          label="Hasheous client API key (optional)"
           description={
             saved
               ? "A key is saved. With one, retro games get IGDB covers, screenshots, genres and developers instead of just a logo and description."
-              : "Without a key you get the keyless baseline: logo + description. Paste a Hasheous client API key to add IGDB covers and screenshots."
+              : "Without a key you get the keyless baseline: logo + description. Add IGDB covers and screenshots with a free key: register at hasheous.org, create an App, then use 'Create Client API Key' on that app's page. This is NOT the Submission API Key on your profile — that one is rejected. Full steps are in the plugin README."
           }
           value={key}
           bIsPassword

--- a/src/components/QuickAccessSettings.tsx
+++ b/src/components/QuickAccessSettings.tsx
@@ -295,7 +295,7 @@ function IgdbKeyRow() {
           description={
             saved
               ? "A key is saved. With one, retro games get IGDB covers, screenshots, genres and developers instead of just a logo and description."
-              : "Without a key you get the keyless baseline: logo + description. Add IGDB covers and screenshots with a free key: register at hasheous.org, create an App, then use 'Create Client API Key' on that app's page. This is NOT the Submission API Key on your profile — that one is rejected. Full steps are in the plugin README."
+              : "Without a key you get the keyless baseline: logo + description. A key adds IGDB covers and screenshots. Note Hasheous only issues client API keys to registered applications, so most users cannot obtain one yet and stay on the baseline. If you do have one, it is the Client API Key from an application's page — NOT the Submission API Key on your profile, which is rejected."
           }
           value={key}
           bIsPassword


### PR DESCRIPTION
Beta testers on `v0.19.0-beta.1` had no instructions for the one manual step the IGDB artwork feature needs. Writing them turned up two findings, the second of which changes what we can promise users.

## Finding 1 — there are three key types, and the obvious one is wrong

Hasheous' OpenAPI spec declares three schemes:

| Scheme | Header |
| --- | --- |
| API Key | `X-API-Key` |
| **Client API Key** | **`X-Client-API-Key`** |
| Task Worker API Key | `X-TaskWorker-API-Key` |

Every `/MetadataProxy/IGDB/*` metadata endpoint is declared `security: [Client API Key]`, which is what the plugin sends. But the key a user finds first is the *Submission API Key* on their profile page, labelled "for your ROM manager tool" — a different scheme, which the proxy answers `401` to. Because IGDB *images* are declared with no security while IGDB *metadata* is keyed, the wrong key degrades to "no artwork appeared" rather than an error.

## Finding 2 — ordinary users cannot obtain a client API key at all

Client API keys are minted against an **App** data object. Creating one does not work on a normal account, and it fails silently:

- `GET /api/v1/DataObjects/App` returns `count: 3` for the entire service — `Gaseous`, `Hasheous Test Client`, `RomM`. All official integrations; a self-serve flow would not leave three rows.
- The button ships as `<button id="dataObjectNew" style="display: none;">`, and `index.js` reveals privileged UI only for `userProfile.Roles.includes('Admin'|'Moderator')`.
- The public spec documents no `DataObjects` write endpoints at all.

Confirmed there is no keyless fallback either: `DataObjects/Game/6292` (Super Metroid) exposes `Logo` as its only image attribute — no cover, no screenshots. Those genuinely require the keyed proxy.

**Consequence:** until EnhancedGV is registered as a Hasheous application — a maintainer-side conversation with that project — the keyless baseline is what users get, and the key field only helps someone who already holds a key.

## Changes

- **README** — new *Metadata & artwork for emulated / non-Steam games* section: what the keyless baseline gives you, a callout that keys are not self-serve and why, the Submission-key warning with both header names, how to enter and clear a key if you have one, a table mapping each **Test artwork lookup** row to what a ✖ means, and the scope limits.
- **CHANGELOG** — the artwork bullet carries the same correction.
- **QAM** — the field is labelled *Hasheous client API key*, and its description says most users cannot obtain one yet rather than sending them hunting.

Docs and UI strings only; no behaviour change.

## Verification

`tsc --noEmit`, `rollup` build and `scripts/check_version.py` clean. Every claim above was checked against the live service rather than recalled.

## Follow-up not in this PR

1. The published `v0.19.0-beta.1` release notes need the corrected text pasted in; editing a release body is blocked from this session.
2. Deciding whether to pursue registering EnhancedGV with Hasheous, or to drop the keyed path and ship the keyless baseline as the whole feature.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JWGu2oG8Q4XtgVyBbuqFdm