### PR TITLE
Promote the beta line to the v0.19.0 stable release

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -19,8 +19,11 @@ permissions:
 # died twice at ~15 minutes and nobody noticed the beta never published. Never
 # auto-cancel a tag (release) run, and cap the job so a hang turns into a red X
 # that does notify.
+# All tag runs share ONE group and never cancel each other, so they serialize:
+# a beta run can never race the stable run that retires it and resurrect the
+# beta after the fact.
 concurrency:
-  group: build-${{ github.ref }}
+  group: ${{ github.ref_type == 'tag' && 'release' || format('build-{0}', github.ref) }}
   cancel-in-progress: ${{ github.ref_type != 'tag' }}
 
 jobs:
@@ -100,51 +103,81 @@ jobs:
           open("release_notes.md", "w", encoding="utf-8").write(m.group(1).strip() + foot)
           EOF
           # Two release shapes, chosen by tag form:
-          #   vX.Y.Z-beta  -> a GitHub PRE-RELEASE. Excluded from /releases/latest,
-          #                   so the stable update channel never sees it; the
-          #                   in-plugin Beta toggle opts in. A beta carries the
-          #                   version it becomes, and its tag is MOVED to newer
-          #                   commits during testing, so an existing release for
-          #                   the tag is replaced rather than appended to.
+          #   vX.Y.Z-beta.N -> a GitHub PRE-RELEASE. Excluded from /releases/latest,
+          #                    so the stable update channel never sees it; the
+          #                    in-plugin Beta toggle opts in. EACH CUT GETS ITS OWN
+          #                    NUMBER: republishing under a reused tag would ship
+          #                    the identical stamped version, and beta-channel
+          #                    testers already on it would never be offered the
+          #                    new build. So an existing published pre-release for
+          #                    this tag is an error, not something to replace.
           #   vX.Y.Z        -> the normal (latest) release. Never overwritten. Once
-          #                   it ships, its beta is retired (release + tag), which
-          #                   is the repo's convention and keeps the list clean.
-          case "${GITHUB_REF_NAME}" in
+          #                    it ships, every vX.Y.Z-beta* pre-release and tag is
+          #                    retired, which keeps the releases list clean.
+          #
+          # In both branches a leftover DRAFT is cleaned up rather than refused:
+          # `gh release create` with assets creates a draft first and publishes
+          # only after upload, so a killed run strands a draft under the tag name
+          # — and `gh release view` finds drafts, so without this the tag could
+          # never be published by CI again.
+          TAG="${GITHUB_REF_NAME}"
+          STABLE="${TAG%%-*}"
+          state_of() {  # -> "published" | "draft" | "" (absent)
+            local d
+            d=$(gh release view "$1" --json isDraft -q .isDraft 2>/dev/null || true)
+            case "$d" in true) echo draft;; false) echo published;; *) echo "";; esac
+          }
+          case "$TAG" in
             *-*)
-              if gh release view "${GITHUB_REF_NAME}" >/dev/null 2>&1; then
-                echo "Replacing existing release for moved beta tag ${GITHUB_REF_NAME}"
-                gh release delete "${GITHUB_REF_NAME}" --yes
+              if [ "$(state_of "$STABLE")" = published ]; then
+                echo "::error::${STABLE} has already shipped; refusing to publish ${TAG}." >&2
+                exit 1
               fi
+              case "$(state_of "$TAG")" in
+                draft)
+                  echo "Removing stranded draft for ${TAG}"
+                  gh release delete "$TAG" --yes ;;
+                published)
+                  echo "::error::${TAG} is already published. Cut the next beta as a NEW tag (${STABLE}-beta.N+1) so beta testers are offered it." >&2
+                  exit 1 ;;
+              esac
               EXTRA="--prerelease"
               ;;
             *)
-              if gh release view "${GITHUB_REF_NAME}" >/dev/null 2>&1; then
-                echo "::error::Release ${GITHUB_REF_NAME} already exists; refusing to overwrite." >&2
-                exit 1
-              fi
+              case "$(state_of "$TAG")" in
+                draft)
+                  echo "Removing stranded draft for ${TAG}"
+                  gh release delete "$TAG" --yes ;;
+                published)
+                  echo "::error::Release ${TAG} already exists; refusing to overwrite." >&2
+                  exit 1 ;;
+              esac
               EXTRA="--latest"
               ;;
           esac
-          gh release create "${GITHUB_REF_NAME}" EnhancedGV.zip $EXTRA \
+          gh release create "$TAG" EnhancedGV.zip $EXTRA \
             --target "${GITHUB_SHA}" \
-            --title "EnhancedGV ${GITHUB_REF_NAME}" \
+            --title "EnhancedGV ${TAG}" \
             --notes-file release_notes.md
 
           # Publishing half-way is worse than failing: the in-plugin updater
           # downloads the asset named exactly EnhancedGV.zip, so verify it landed.
-          gh release view "${GITHUB_REF_NAME}" --json assets \
+          gh release view "$TAG" --json assets \
             -q '.assets[].name' | grep -qx 'EnhancedGV.zip' \
-            || { echo "::error::EnhancedGV.zip missing from ${GITHUB_REF_NAME}" >&2; exit 1; }
+            || { echo "::error::EnhancedGV.zip missing from ${TAG}" >&2; exit 1; }
 
-          # A shipped stable release retires its beta: the pre-release and the
-          # tag it hangs on. Beta-channel testers are offered the stable build by
-          # version order, so nothing is left dangling for them.
-          case "${GITHUB_REF_NAME}" in
+          # A shipped stable release retires every one of its betas — release AND
+          # tag. Beta-channel testers are offered the stable build by version
+          # order, so nothing is left dangling for them.
+          case "$TAG" in
             *-*) ;;
             *)
-              if gh release view "${GITHUB_REF_NAME}-beta" >/dev/null 2>&1; then
-                echo "Retiring ${GITHUB_REF_NAME}-beta now that ${GITHUB_REF_NAME} has shipped"
-                gh release delete "${GITHUB_REF_NAME}-beta" --yes --cleanup-tag
-              fi
+              gh release list --limit 100 --json tagName,isPrerelease \
+                -q ".[] | select(.isPrerelease and (.tagName | startswith(\"${TAG}-\"))) | .tagName" \
+              | while read -r t; do
+                  [ -n "$t" ] || continue
+                  echo "Retiring $t now that ${TAG} has shipped"
+                  gh release delete "$t" --yes --cleanup-tag
+                done
               ;;
           esac

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -55,6 +55,19 @@ jobs:
           mkdir -p "dist_pkg/$PLUGIN"
           cp -r dist "dist_pkg/$PLUGIN/dist"
           cp main.py plugin.json package.json decky.pyi LICENSE README.md CHANGELOG.md "dist_pkg/$PLUGIN/"
+          # A tag build stamps the FULL tag version into the packaged manifests
+          # (zip only — git stays at the bare X.Y.Z). So a beta installs as
+          # "0.19.0-beta": Decky displays it, and the in-plugin updater can tell
+          # it apart from the finished 0.19.0 and offer that when it ships. The
+          # version gate already proved the tag matches the tree's X.Y.Z.
+          if [ "${GITHUB_REF_TYPE}" = "tag" ]; then
+            V="${GITHUB_REF_NAME#v}"
+            for f in package.json plugin.json; do
+              jq --arg v "$V" '.version = $v' "dist_pkg/$PLUGIN/$f" > "dist_pkg/$PLUGIN/$f.tmp"
+              mv "dist_pkg/$PLUGIN/$f.tmp" "dist_pkg/$PLUGIN/$f"
+            done
+            echo "Stamped packaged version: $V"
+          fi
           cd dist_pkg
           zip -r "../$PLUGIN.zip" "$PLUGIN"
 
@@ -86,28 +99,30 @@ jobs:
                   f"publish a release with placeholder notes.")
           open("release_notes.md", "w", encoding="utf-8").write(m.group(1).strip() + foot)
           EOF
-          # A hyphenated tag (e.g. v0.17.0-beta) is a PRIVATE beta: publish it as a
-          # DRAFT release, which is visible only to repo collaborators and is
-          # excluded from the public releases API — so it can never reach anyone on
-          # the stable channel. A plain vX.Y.Z tag publishes a normal (latest) release.
+          # Two release shapes, chosen by tag form:
+          #   vX.Y.Z-beta  -> a GitHub PRE-RELEASE. Excluded from /releases/latest,
+          #                   so the stable update channel never sees it; the
+          #                   in-plugin Beta toggle opts in. A beta carries the
+          #                   version it becomes, and its tag is MOVED to newer
+          #                   commits during testing, so an existing release for
+          #                   the tag is replaced rather than appended to.
+          #   vX.Y.Z        -> the normal (latest) release. Never overwritten. Once
+          #                   it ships, its beta is retired (release + tag), which
+          #                   is the repo's convention and keeps the list clean.
           case "${GITHUB_REF_NAME}" in
             *-*)
-              # Private beta: a DRAFT prerelease, invisible to stable users.
-              # Remove any stale draft for this tag first — otherwise the new zip
-              # is attached to a release still describing an older commit.
-              if gh release view "${GITHUB_REF_NAME}" --json isDraft -q .isDraft 2>/dev/null | grep -qx true; then
-                echo "Deleting stale draft for ${GITHUB_REF_NAME}"
+              if gh release view "${GITHUB_REF_NAME}" >/dev/null 2>&1; then
+                echo "Replacing existing release for moved beta tag ${GITHUB_REF_NAME}"
                 gh release delete "${GITHUB_REF_NAME}" --yes
               fi
-              EXTRA="--draft --prerelease"
+              EXTRA="--prerelease"
               ;;
             *)
-              # Public release: never overwrite one that already exists.
               if gh release view "${GITHUB_REF_NAME}" >/dev/null 2>&1; then
                 echo "::error::Release ${GITHUB_REF_NAME} already exists; refusing to overwrite." >&2
                 exit 1
               fi
-              EXTRA=""
+              EXTRA="--latest"
               ;;
           esac
           gh release create "${GITHUB_REF_NAME}" EnhancedGV.zip $EXTRA \
@@ -120,3 +135,16 @@ jobs:
           gh release view "${GITHUB_REF_NAME}" --json assets \
             -q '.assets[].name' | grep -qx 'EnhancedGV.zip' \
             || { echo "::error::EnhancedGV.zip missing from ${GITHUB_REF_NAME}" >&2; exit 1; }
+
+          # A shipped stable release retires its beta: the pre-release and the
+          # tag it hangs on. Beta-channel testers are offered the stable build by
+          # version order, so nothing is left dangling for them.
+          case "${GITHUB_REF_NAME}" in
+            *-*) ;;
+            *)
+              if gh release view "${GITHUB_REF_NAME}-beta" >/dev/null 2>&1; then
+                echo "Retiring ${GITHUB_REF_NAME}-beta now that ${GITHUB_REF_NAME} has shipped"
+                gh release delete "${GITHUB_REF_NAME}-beta" --yes --cleanup-tag
+              fi
+              ;;
+          esac

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -2,10 +2,14 @@ name: Build EnhancedGV
 
 on:
   push:
-    branches: [main]
+    branches: [main, beta]
     tags: ["v*"]
   pull_request:
-    branches: [main]
+    # `beta` is a release line too (betas are cut from it and tagged
+    # vX.Y.Z-beta), so PRs into it need the same build gate as main —
+    # without it a beta-targeted PR reports NO checks at all, which reads
+    # like "nothing failed" when nothing actually ran.
+    branches: [main, beta]
   workflow_dispatch:
 
 permissions:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -15,15 +15,29 @@ on:
 permissions:
   contents: write # needed to create releases on tag pushes
 
+# A CANCELLED run sends no notification — which is exactly why tag v0.19.0-beta
+# died twice at ~15 minutes and nobody noticed the beta never published. Never
+# auto-cancel a tag (release) run, and cap the job so a hang turns into a red X
+# that does notify.
+concurrency:
+  group: build-${{ github.ref }}
+  cancel-in-progress: ${{ github.ref_type != 'tag' }}
+
 jobs:
   build:
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     steps:
       - uses: actions/checkout@v4
 
       - uses: actions/setup-node@v4
         with:
           node-version: 20
+
+      # Cheap, no network, no deps — fail in seconds on version drift rather
+      # than after a full build. See scripts/check_version.py for the history.
+      - name: Check version consistency
+        run: python3 scripts/check_version.py
 
       - name: Install dependencies
         run: npm install
@@ -63,24 +77,46 @@ jobs:
           tag = os.environ["GITHUB_REF_NAME"].lstrip("v")
           base = tag.split("-")[0]
           foot = "\n\n---\nInstall via Decky → Developer → Install Plugin from ZIP. The plugin's Updates section checks for and links to new releases."
-          notes = f"Automated build for v{tag}.{foot}"
-          try:
-              text = open("CHANGELOG.md", encoding="utf-8").read()
-              m = (re.search(rf"^## v{re.escape(tag)}\n(.*?)(?=^## |\Z)", text, re.S | re.M)
-                   or re.search(rf"^## v{re.escape(base)}\n(.*?)(?=^## |\Z)", text, re.S | re.M))
-              if m and m.group(1).strip():
-                  notes = m.group(1).strip() + foot
-          except OSError:
-              pass
-          open("release_notes.md", "w", encoding="utf-8").write(notes)
+          text = open("CHANGELOG.md", encoding="utf-8").read()
+          m = (re.search(rf"^## v{re.escape(tag)}\s*$\n(.*?)(?=^## |\Z)", text, re.S | re.M)
+               or re.search(rf"^## v{re.escape(base)}\s*$\n(.*?)(?=^## |\Z)", text, re.S | re.M))
+          if not (m and m.group(1).strip()):
+              raise SystemExit(
+                  f"No CHANGELOG.md section for v{tag} (or v{base}). Refusing to "
+                  f"publish a release with placeholder notes.")
+          open("release_notes.md", "w", encoding="utf-8").write(m.group(1).strip() + foot)
           EOF
           # A hyphenated tag (e.g. v0.17.0-beta) is a PRIVATE beta: publish it as a
           # DRAFT release, which is visible only to repo collaborators and is
           # excluded from the public releases API — so it can never reach anyone on
           # the stable channel. A plain vX.Y.Z tag publishes a normal (latest) release.
-          EXTRA=""
-          case "${GITHUB_REF_NAME}" in *-*) EXTRA="--draft --prerelease";; esac
+          case "${GITHUB_REF_NAME}" in
+            *-*)
+              # Private beta: a DRAFT prerelease, invisible to stable users.
+              # Remove any stale draft for this tag first — otherwise the new zip
+              # is attached to a release still describing an older commit.
+              if gh release view "${GITHUB_REF_NAME}" --json isDraft -q .isDraft 2>/dev/null | grep -qx true; then
+                echo "Deleting stale draft for ${GITHUB_REF_NAME}"
+                gh release delete "${GITHUB_REF_NAME}" --yes
+              fi
+              EXTRA="--draft --prerelease"
+              ;;
+            *)
+              # Public release: never overwrite one that already exists.
+              if gh release view "${GITHUB_REF_NAME}" >/dev/null 2>&1; then
+                echo "::error::Release ${GITHUB_REF_NAME} already exists; refusing to overwrite." >&2
+                exit 1
+              fi
+              EXTRA=""
+              ;;
+          esac
           gh release create "${GITHUB_REF_NAME}" EnhancedGV.zip $EXTRA \
+            --target "${GITHUB_SHA}" \
             --title "EnhancedGV ${GITHUB_REF_NAME}" \
-            --notes-file release_notes.md \
-            || gh release upload "${GITHUB_REF_NAME}" EnhancedGV.zip --clobber
+            --notes-file release_notes.md
+
+          # Publishing half-way is worse than failing: the in-plugin updater
+          # downloads the asset named exactly EnhancedGV.zip, so verify it landed.
+          gh release view "${GITHUB_REF_NAME}" --json assets \
+            -q '.assets[].name' | grep -qx 'EnhancedGV.zip' \
+            || { echo "::error::EnhancedGV.zip missing from ${GITHUB_REF_NAME}" >&2; exit 1; }

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -42,6 +42,13 @@ jobs:
       - name: Check version consistency
         run: python3 scripts/check_version.py
 
+      # The frontend reaches the backend by STRING name (callable<>("get_all")),
+      # so tsc cannot see a method that was renamed or deleted. 63078f1 dropped
+      # get_all_provider while editing the same region and three beta cuts
+      # shipped with the entire non-Steam path answering "unknown method".
+      - name: Check frontend/backend callable contract
+        run: python3 scripts/check_callables.py
+
       - name: Install dependencies
         run: npm install
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,23 @@ Six issues were confirmed and fixed in this build:
   could otherwise choose where the "download the update" link sent you.
 - **The trailer diagnostic only speaks https**, so an upstream response cannot
   point it at local files or the local network.
+- **Steam news can no longer inject script into the panel.** A link or image URL
+  in an announcement could break out of the HTML attribute it was placed in. News
+  content now also goes through the same allowlist filter everything else uses.
+- **The URL filter no longer has an encoding blind spot.** A single HTML entity
+  could hide a `javascript:` scheme from it.
+- **A game description can no longer freeze the plugin.** A pathological run of
+  whitespace made the on-device HTML parser take tens of seconds; it is now
+  linear, and oversized fields are truncated.
+- **Plain-text descriptions are rendered as text**, not as HTML.
+- **Links open only if they are ordinary web links.** `steam://` and `file://`
+  targets from a store or news response are ignored rather than handed to the
+  Steam client.
+- **Trailer URLs must be Steam's own CDN**, so a tampered store response cannot
+  point the player at another host, and a malformed manifest can no longer
+  exhaust memory.
+- **Matching a non-Steam game is bounded**, so one page open cannot turn into
+  thousands of lookups.
 
 
 > **Fixed since beta.3:** the non-Steam path was not reachable at all. The panel

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,25 +1,5 @@
 # Changelog
 
-## v0.20.0
-
-- **Artwork for emulated / non-Steam games (opt-in, needs a free key).** The
-  non-Steam support added in 0.19.0 could only show a logo and a description.
-  Paste a **Hasheous API key** in Quick Access → EnhancedGV → *Non-Steam games*
-  and retro titles now get proper **cover art, screenshots, genres and
-  developers** from IGDB — so the media gallery works for a SNES ROM the same
-  way it does for a Steam game.
-  - Entirely optional. With no key, nothing changes: you still get the keyless
-    logo + description baseline.
-  - Steam games are untouched — this only affects games matched to a non-Steam
-    source.
-  - **Test artwork lookup** button reports, step by step, whether the key was
-    accepted and whether artwork came back, so a failure tells you *which* part
-    broke instead of just showing an empty gallery.
-  - Images load in display sizes rather than originals (a cover is ~21 KB
-    instead of ~2.7 MB), so the gallery doesn't stall on a handheld connection.
-  - The panel header now notes where non-Steam content came from
-    ("via Hasheous + IGDB").
-
 ## v0.19.0
 
 - **Metadata for emulated / non-Steam games (experimental, off by default).** When
@@ -36,8 +16,24 @@
     sections simply don't appear for a non-Steam game.
   - You can still override any match by hand (Quick Access → *Store data source*).
   - This is the keyless baseline (title, description, genres, developer/publisher,
-    platform, logo). Richer artwork/screenshots via an optional API key are a
-    later step.
+    platform, logo).
+- **Optional artwork upgrade for those games (needs a free key).** The keyless
+  baseline above shows a logo and a description. Paste a **Hasheous API key** in
+  Quick Access → EnhancedGV → *Non-Steam games* and retro titles also get proper
+  **cover art, screenshots, genres and developers** from IGDB — so the media
+  gallery works for a SNES ROM the same way it does for a Steam game.
+  - Entirely optional; with no key you get the keyless baseline unchanged.
+  - Steam games are untouched — this only affects games matched to a non-Steam
+    source.
+  - **Test artwork lookup** reports, step by step, whether the key was accepted
+    and whether artwork came back, so a failure tells you *which* part broke
+    instead of just showing an empty gallery.
+  - Images load in display sizes rather than originals (a cover is ~21 KB
+    instead of ~2.7 MB), so the gallery doesn't stall on a handheld connection.
+  - Trailers stay Steam-only: IGDB supplies YouTube ids, not playable video
+    URLs.
+  - The panel header notes where non-Steam content came from
+    ("via Hasheous + IGDB").
 - **The panel appears far sooner on a game page.** It used to wait for a
   once-every-2-seconds re-sync to notice the page had finished laying out, so on
   most page loads it arrived a beat or two after everything else. It now retries

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,11 +18,16 @@
   - This is the keyless baseline (title, description, genres, developer/publisher,
     platform, logo).
 - **Optional artwork upgrade for those games (needs a free key).** The keyless
-  baseline above shows a logo and a description. Paste a **Hasheous API key** in
-  Quick Access → EnhancedGV → *Non-Steam games* and retro titles also get proper
-  **cover art, screenshots, genres and developers** from IGDB — so the media
+  baseline above shows a logo and a description. Paste a **Hasheous client API
+  key** in Quick Access → EnhancedGV → *Non-Steam games* and retro titles also
+  get proper **cover art, screenshots, genres and developers** from IGDB — so the media
   gallery works for a SNES ROM the same way it does for a Steam game.
   - Entirely optional; with no key you get the keyless baseline unchanged.
+  - **Setting it up:** register at hasheous.org, create an app, and mint a *Client
+    API Key* against it — the step-by-step is in the README under *Setup & tips →
+    Metadata & artwork for emulated / non-Steam games*. Note this is **not** the
+    *Submission API Key* on your Hasheous profile page; that one is for ROM
+    managers and the metadata proxy rejects it with HTTP 401.
   - Steam games are untouched — this only affects games matched to a non-Steam
     source.
   - **Test artwork lookup** reports, step by step, whether the key was accepted

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,26 @@
 
 ## v0.19.0
 
+### Testing non-Steam / emulated game metadata
+
+Turn on **Quick Access → EnhancedGV → Non-Steam games (experimental)**, then open a
+ROM that was added to your library as its own shortcut. You should get a title,
+description, genres, developer/publisher, platform and a logo, sourced from
+**Hasheous**. That is the whole feature for now, and it needs no account and no key.
+
+Cover art and screenshots come from IGDB through Hasheous' *keyed* proxy, and those
+client API keys are **not self-serve**: Hasheous issues them per registered
+application, and creating an application is restricted to its admins and moderators
+— on a normal account the **New** button silently does nothing. Only three
+applications exist service-wide, all official integrations. So **leave the key field
+empty** unless you already hold a client API key. If you do have one, note it is not
+the *Submission API Key* from your Hasheous profile; that is a different key type and
+the proxy rejects it with `HTTP 401`.
+
+**Test artwork lookup** (same panel) reports each stage separately if you want to see
+where things stop.
+
+
 - **Metadata for emulated / non-Steam games (experimental, off by default).** When
   a non-Steam game has no Steam store page, EnhancedGV can now pull a description,
   details and artwork from **Hasheous** — a free, keyless community game database.
@@ -17,7 +37,7 @@
   - You can still override any match by hand (Quick Access → *Store data source*).
   - This is the keyless baseline (title, description, genres, developer/publisher,
     platform, logo).
-- **Optional artwork upgrade for those games (needs a free key).** The keyless
+- **Optional artwork upgrade for those games (needs a key you probably can't get yet).** The keyless
   baseline above shows a logo and a description. Paste a **Hasheous client API
   key** in Quick Access → EnhancedGV → *Non-Steam games* and retro titles also
   get proper **cover art, screenshots, genres and developers** from IGDB — so the media

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,9 +37,13 @@
 - **Beta channel is back.** Quick Access → EnhancedGV → Updates → *Beta channel
   (test builds)*. Betas are now published as GitHub pre-releases instead of
   private drafts, so the toggle can actually see them; stable users are never
-  offered one. A beta installs as e.g. `0.19.0-beta`, and you'll be offered the
-  finished release when it ships — previously the updater treated the two as
+  offered one. Each beta cut is numbered (`0.19.0-beta.1`, `.2`, …) and installs
+  under that version, so you're offered the next cut and, when it ships, the
+  finished release — previously the updater treated a beta and its release as
   the same version and left beta testers stranded.
+- **Store content survives a flaky connection.** If a background refresh of
+  cached store data fails (offline, rate-limited), the last good copy is kept
+  instead of being replaced by the error.
 - **The panel appears far sooner on a game page.** It used to wait for a
   once-every-2-seconds re-sync to notice the page had finished laying out, so on
   most page loads it arrived a beat or two after everything else. It now retries

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,12 @@
     URLs.
   - The panel header notes where non-Steam content came from
     ("via Hasheous + IGDB").
+- **Beta channel is back.** Quick Access → EnhancedGV → Updates → *Beta channel
+  (test builds)*. Betas are now published as GitHub pre-releases instead of
+  private drafts, so the toggle can actually see them; stable users are never
+  offered one. A beta installs as e.g. `0.19.0-beta`, and you'll be offered the
+  finished release when it ships — previously the updater treated the two as
+  the same version and left beta testers stranded.
 - **The panel appears far sooner on a game page.** It used to wait for a
   once-every-2-seconds re-sync to notice the page had finished laying out, so on
   most page loads it arrived a beat or two after everything else. It now retries

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,27 @@
 
 ### Testing non-Steam / emulated game metadata
 
+### Security
+
+A multi-lens audit ran over the plugin once it started collecting credentials.
+Six issues were confirmed and fixed in this build:
+
+- **The IGDB client secret is no longer readable by other plugins.** `get_settings`
+  is an unauthenticated RPC that any code in the Steam UI can call, and it was
+  returning the secret in cleartext. It now reports only whether one is stored.
+- **The file holding it is no longer world-readable.** It was written `0644` in a
+  `0755` directory, next to a token file that was correctly `0600`.
+- **Credentials no longer follow redirects.** A redirect from IGDB would have
+  re-sent the bearer token and client id to any host, over plain HTTP.
+- **Certificate verification is no longer dropped automatically.** On a
+  certificate error the plugin used to silently retry unverified, which handed an
+  on-path attacker control of every Steam, Hasheous and GitHub response.
+- **Update links are pinned to GitHub over https.** A forged release response
+  could otherwise choose where the "download the update" link sent you.
+- **The trailer diagnostic only speaks https**, so an upstream response cannot
+  point it at local files or the local network.
+
+
 > **Fixed since beta.3:** the non-Steam path was not reachable at all. The panel
 > calls a backend method that an earlier commit had deleted, so every non-Steam
 > game failed before any provider was contacted. If you tried beta.1, beta.2 or

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,8 +6,12 @@
 
 ### Security
 
-A multi-lens audit ran over the plugin once it started collecting credentials.
-Six issues were confirmed and fixed in this build:
+A multi-lens audit ran over the plugin once it started collecting credentials:
+65 candidate issues, each reviewed by three independent verifiers. Seventeen were
+confirmed and all are fixed in this build.
+
+Three of them were **not** new — they also affect v0.18.0, the current stable
+release: the news injection, the URL filter blind spot, and the freeze.
 
 - **The IGDB client secret is no longer readable by other plugins.** `get_settings`
   is an unauthenticated RPC that any code in the Steam UI can call, and it was

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,14 +9,15 @@ ROM that was added to your library as its own shortcut. You should get a title,
 description, genres, developer/publisher, platform and a logo, sourced from
 **Hasheous**. That is the whole feature for now, and it needs no account and no key.
 
-Cover art and screenshots come from IGDB through Hasheous' *keyed* proxy, and those
-client API keys are **not self-serve**: Hasheous issues them per registered
-application, and creating an application is restricted to its admins and moderators
-— on a normal account the **New** button silently does nothing. Only three
-applications exist service-wide, all official integrations. So **leave the key field
-empty** unless you already hold a client API key. If you do have one, note it is not
-the *Submission API Key* from your Hasheous profile; that is a different key type and
-the proxy rejects it with `HTTP 401`.
+Cover art and screenshots come from **IGDB**, which the plugin now queries
+directly. That is optional and free to set up: a Twitch account with two-factor
+enabled, an application registered at dev.twitch.tv with Client Type
+*Confidential*, then paste its Client ID and Client Secret into the same panel.
+The README has the step-by-step.
+
+(Earlier betas tried to reach IGDB through Hasheous' proxy, which needs a client
+API key that only Hasheous admins can issue — so that field could never be
+filled. Going direct removes the gatekeeper.)
 
 **Test artwork lookup** (same panel) reports each stage separately if you want to see
 where things stop.
@@ -37,20 +38,22 @@ where things stop.
   - You can still override any match by hand (Quick Access → *Store data source*).
   - This is the keyless baseline (title, description, genres, developer/publisher,
     platform, logo).
-- **Optional artwork upgrade for those games (needs a key you probably can't get yet).** The keyless
-  baseline above shows a logo and a description. Paste a **Hasheous client API
-  key** in Quick Access → EnhancedGV → *Non-Steam games* and retro titles also
-  get proper **cover art, screenshots, genres and developers** from IGDB — so the media
-  gallery works for a SNES ROM the same way it does for a Steam game.
-  - Entirely optional; with no key you get the keyless baseline unchanged.
-  - **Getting a key is not self-serve yet.** Hasheous issues client API keys per
-    *registered application*, and creating an application is admin/moderator-only
-    — only three exist service-wide, all official integrations. Until EnhancedGV
-    is registered, most users stay on the keyless baseline. Details in the README
-    under *Setup & tips → Metadata & artwork for emulated / non-Steam games*.
-  - If you do have a key, note it is **not** the *Submission API Key* on your
-    Hasheous profile page; that is a different key type and the metadata proxy
-    rejects it with HTTP 401.
+- **Optional artwork upgrade for those games (free IGDB credentials).** The
+  keyless baseline above shows a logo and a description. Add IGDB credentials in
+  Quick Access → EnhancedGV → *Non-Steam games* and retro titles also get proper
+  **cover art, screenshots, genres and developers** — so the media gallery works
+  for a SNES ROM the same way it does for a Steam game.
+  - Entirely optional; with no credentials you get the keyless baseline unchanged.
+  - **IGDB is queried directly** rather than through Hasheous' metadata proxy.
+    The proxy needs a client API key issued per registered application, and only
+    Hasheous admins can create one — three exist service-wide. IGDB's own API is
+    free and self-serve, so anyone can turn this on.
+  - One expanded request per game now returns the cover, screenshots, genres and
+    companies together. The proxy route needed a separate request for every
+    image id.
+  - The access token is minted from your credentials, cached for its ~60-day
+    life and refreshed automatically. The secret travels in a form body, never a
+    URL, and is never logged or shown by the diagnostic.
   - Steam games are untouched — this only affects games matched to a non-Steam
     source.
   - **Test artwork lookup** reports, step by step, whether the key was accepted

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,25 @@
 # Changelog
 
+## v0.20.0
+
+- **Artwork for emulated / non-Steam games (opt-in, needs a free key).** The
+  non-Steam support added in 0.19.0 could only show a logo and a description.
+  Paste a **Hasheous API key** in Quick Access → EnhancedGV → *Non-Steam games*
+  and retro titles now get proper **cover art, screenshots, genres and
+  developers** from IGDB — so the media gallery works for a SNES ROM the same
+  way it does for a Steam game.
+  - Entirely optional. With no key, nothing changes: you still get the keyless
+    logo + description baseline.
+  - Steam games are untouched — this only affects games matched to a non-Steam
+    source.
+  - **Test artwork lookup** button reports, step by step, whether the key was
+    accepted and whether artwork came back, so a failure tells you *which* part
+    broke instead of just showing an empty gallery.
+  - Images load in display sizes rather than originals (a cover is ~21 KB
+    instead of ~2.7 MB), so the gallery doesn't stall on a handheld connection.
+  - The panel header now notes where non-Steam content came from
+    ("via Hasheous + IGDB").
+
 ## v0.19.0
 
 - **Metadata for emulated / non-Steam games (experimental, off by default).** When

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,71 @@
 
 ### Testing non-Steam / emulated game metadata
 
+> **Fixed since beta.3:** the non-Steam path was not reachable at all. The panel
+> called a backend method an earlier commit had deleted, so every non-Steam game
+> failed before any provider was contacted. If you tried beta.1, beta.2 or beta.3
+> and nothing happened for a ROM, that is why. This is the first build where the
+> feature actually runs.
+
+**Step 1 — the keyless part, which is most of it.**
+
+Turn on **Quick Access → EnhancedGV → Non-Steam games (experimental)**, then open a
+ROM that was added to your library as its own shortcut. You should get a title,
+description, genres, developer/publisher, platform and a logo, from **Hasheous**.
+No account, no key, nothing to sign up for. Test this first.
+
+**Step 2 — cover art and screenshots, optional, free.**
+
+These come from **IGDB**, which the plugin queries directly. IGDB is owned by
+Twitch and uses Twitch developer accounts, so setup happens there:
+
+1. Create a **Twitch account** at <https://twitch.tv> if you don't have one.
+2. **Enable two-factor authentication** on it. The developer console refuses to
+   register an application without it, and this is the step people miss.
+3. Go to <https://dev.twitch.tv/console/apps> and press **Register Your
+   Application**. Name it anything.
+4. Set **OAuth Redirect URL** to `http://localhost`. IGDB never uses it, but the
+   form demands a value.
+5. Set **Client Type** to **Confidential**. This is the setting that allows a
+   secret to exist. Get it wrong and step 7 fails with "Twitch rejected the
+   client id/secret pair".
+6. Copy the **Client ID**.
+7. Press **New Secret** and copy the **Client Secret**. It is shown once.
+8. On the Deck, paste both into the same EnhancedGV panel and press **Save
+   credentials**.
+
+Free for non-commercial use, limited to 4 requests per second, far above anything
+this plugin does. Saving clears cached data so games you already opened refetch
+with artwork. **Remove credentials** goes back to step 1 at any time.
+
+Your secret is stored on the device, sent only to `id.twitch.tv` to mint a token,
+and never written to the log or shown by the diagnostic.
+
+**Step 3 — check it.**
+
+Open a retro game's page and press **Test artwork lookup**. It reports each stage
+separately, so a failure names itself rather than showing an empty gallery:
+
+| Stage | A ✖ here means |
+| --- | --- |
+| Non-Steam sources enabled | The toggle in step 1 is off. |
+| Credentials present | One of the two fields is empty. |
+| Access token from Twitch | Twitch rejected the pair — usually Client Type was not **Confidential**, or the secret was regenerated after you saved it. |
+| This game maps to IGDB | Hasheous has no IGDB link for *this* title. Not fatal: the credentials are then tested against a known game, so the rows below still tell you if they work. |
+| IGDB game fetched | `401`/`403` = token or client id rejected. `429` = over the rate limit. |
+| Screenshots listed | Credentials work; IGDB simply has no screenshots for that title. |
+| Image address resolved | Screenshots exist but carried no image id. Please report this one. |
+
+**Known limits.** Steam games are untouched. No trailers, because IGDB supplies
+YouTube ids rather than playable URLs. A single emulator or frontend shortcut
+covering your whole library has no per-game page to attach to.
+
+**Please report:** whether step 1 works on your ROMs, and if you do step 2,
+whether the token stage passes. That second one has never run against a live
+IGDB response — there are no credentials on the build machine — so you are the
+first to exercise it.
+
+
 ### Security
 
 A multi-lens audit ran over the plugin once it started collecting credentials:
@@ -46,33 +111,6 @@ release: the news injection, the URL filter blind spot, and the freeze.
   thousands of lookups.
 
 
-> **Fixed since beta.3:** the non-Steam path was not reachable at all. The panel
-> calls a backend method that an earlier commit had deleted, so every non-Steam
-> game failed before any provider was contacted. If you tried beta.1, beta.2 or
-> beta.3 and saw nothing happen for a ROM, that is why — this build is the first
-> where the feature actually runs.
-
-
-Turn on **Quick Access → EnhancedGV → Non-Steam games (experimental)**, then open a
-ROM that was added to your library as its own shortcut. You should get a title,
-description, genres, developer/publisher, platform and a logo, sourced from
-**Hasheous**. That is the whole feature for now, and it needs no account and no key.
-
-Cover art and screenshots come from **IGDB**, which the plugin now queries
-directly. That is optional and free to set up: a Twitch account with two-factor
-enabled, an application registered at dev.twitch.tv with Client Type
-*Confidential*, then paste its Client ID and Client Secret into the same panel.
-The README has the step-by-step.
-
-(Earlier betas tried to reach IGDB through Hasheous' proxy, which needs a client
-API key that only Hasheous admins can issue — so that field could never be
-filled. Going direct removes the gatekeeper.)
-
-**Test artwork lookup** (same panel) reports each stage separately if you want to see
-where things stop.
-
-
-- **Metadata for emulated / non-Steam games (experimental, off by default).** When
   a non-Steam game has no Steam store page, EnhancedGV can now pull a description,
   details and artwork from **Hasheous** — a free, keyless community game database.
   Turn it on in Quick Access → EnhancedGV → *Non-Steam games (experimental)*.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@
 
 ### Testing non-Steam / emulated game metadata
 
+> **Fixed since beta.3:** the non-Steam path was not reachable at all. The panel
+> calls a backend method that an earlier commit had deleted, so every non-Steam
+> game failed before any provider was contacted. If you tried beta.1, beta.2 or
+> beta.3 and saw nothing happen for a ROM, that is why — this build is the first
+> where the feature actually runs.
+
+
 Turn on **Quick Access → EnhancedGV → Non-Steam games (experimental)**, then open a
 ROM that was added to your library as its own shortcut. You should get a title,
 description, genres, developer/publisher, platform and a logo, sourced from

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,11 +23,14 @@
   get proper **cover art, screenshots, genres and developers** from IGDB — so the media
   gallery works for a SNES ROM the same way it does for a Steam game.
   - Entirely optional; with no key you get the keyless baseline unchanged.
-  - **Setting it up:** register at hasheous.org, create an app, and mint a *Client
-    API Key* against it — the step-by-step is in the README under *Setup & tips →
-    Metadata & artwork for emulated / non-Steam games*. Note this is **not** the
-    *Submission API Key* on your Hasheous profile page; that one is for ROM
-    managers and the metadata proxy rejects it with HTTP 401.
+  - **Getting a key is not self-serve yet.** Hasheous issues client API keys per
+    *registered application*, and creating an application is admin/moderator-only
+    — only three exist service-wide, all official integrations. Until EnhancedGV
+    is registered, most users stay on the keyless baseline. Details in the README
+    under *Setup & tips → Metadata & artwork for emulated / non-Steam games*.
+  - If you do have a key, note it is **not** the *Submission API Key* on your
+    Hasheous profile page; that is a different key type and the metadata proxy
+    rejects it with HTTP 401.
   - Steam games are untouched — this only affects games matched to a non-Steam
     source.
   - **Test artwork lookup** reports, step by step, whether the key was accepted

--- a/README.md
+++ b/README.md
@@ -61,8 +61,8 @@ Access** panel.
   APIs (bypassing the browser's CORS restrictions), **normalizes and
   allowlist-sanitizes** the HTML/JSON, converts news BBCODE → safe HTML, resolves
   non-Steam games to a store appid by title search, enriches non-Steam matches
-  with IGDB artwork when a Hasheous API key is set (metadata via the keyed
-  proxy; images from IGDB's public CDN in display sizes), and caches responses to disk
+  with IGDB artwork when IGDB credentials are set (one expanded query against
+  IGDB's own API; images from its public CDN in display sizes), and caches responses to disk
   (`DECKY_PLUGIN_RUNTIME_DIR`) with per-kind TTLs plus negative caching and
   in-flight de-duplication to stay well under Steam's rate limits. Expired
   entries are served **stale-while-revalidate** — the last known-good copy is
@@ -178,43 +178,47 @@ Games that have no Steam store page at all (SNES/PS1/etc. ROMs added as individu
 shortcuts) fall back to **Hasheous**, a free community game database. Turn on
 **Quick Access → EnhancedGV → Non-Steam games (experimental)**.
 
-Without a key this is the *keyless baseline*: title, description, genres,
+Without credentials this is the *keyless baseline*: title, description, genres,
 developer/publisher, platform and a logo. To also get **cover art, screenshots,
-genres and developers** from IGDB, add a free Hasheous **client API key** — IGDB
-metadata is served through Hasheous' keyed proxy, so requests without a key are
-rejected with `HTTP 401`. Images themselves are keyless.
+genres and developers** from IGDB, add free IGDB credentials.
 
-> ⚠️ **A client API key is not self-serve today.** Hasheous issues client API keys
-> *per registered application*, and creating an application is restricted to
-> Hasheous admins/moderators — on a normal account the **New** button on the Apps
-> page silently does nothing, because the request is refused server-side with no
-> message. At the time of writing only three applications exist on the whole
-> service (Gaseous, Hasheous Test Client and RomM), all of them official
-> integrations. So unless you already hold a key, **the keyless baseline is what
-> you get**, and the key field below is only useful if EnhancedGV is registered
-> with Hasheous or you have been issued a key another way.
->
-> Tracking this: getting EnhancedGV registered as a Hasheous application is a
-> maintainer-side conversation with the Hasheous project, not something an
-> individual user can do.
+> **Why not a Hasheous key?** Hasheous does proxy IGDB, but every metadata
+> endpoint there requires a *client API key*, and those are issued per registered
+> application — creating one is restricted to Hasheous admins and moderators, so
+> on a normal account the **New** button silently does nothing. Only three
+> applications exist service-wide, all official integrations. EnhancedGV talks to
+> IGDB directly instead, which anyone can sign up for. Hasheous is still what
+> matches your ROM to a game, and that half needs no key at all.
 
-*If you already have a client API key,* it is the one created under **Create Client
-API Key** on an application's page (revealed once, under *Your Client API Key*).
+*Getting IGDB credentials (free, self-serve, about five minutes):*
 
-> ⚠️ **It is not the "Submission API Key."** Your Hasheous profile page shows one of
-> those, described as being "for your ROM manager tool". That is a different key
-> type (`X-API-Key` rather than `X-Client-API-Key`), and the metadata proxy
-> **rejects** it with `HTTP 401`. Because IGDB *images* are un-keyed while IGDB
-> *metadata* is keyed, using the wrong key looks like "no artwork appeared" rather
-> than an error.
+1. **Create a Twitch account** at <https://twitch.tv> if you don't have one. IGDB
+   is owned by Twitch and uses its developer accounts.
+2. **Enable two-factor authentication** on it. The developer console refuses to
+   register an application without it.
+3. **Register an application** at <https://dev.twitch.tv/console/apps> → *Register
+   Your Application*. Name it anything. Set **OAuth Redirect URL** to
+   `http://localhost` (IGDB doesn't use it, but the form requires one) and set
+   **Client Type** to **Confidential** — this is the setting that allows a client
+   secret to be generated.
+4. **Copy the Client ID**, then press **[New Secret]** and copy the **Client
+   Secret**. The secret is shown once.
 
-*Entering it on the Deck:*
+IGDB is free for non-commercial use and allows 4 requests per second, far above
+anything this plugin does.
+
+*Entering them on the Deck:*
 
 1. **Quick Access → EnhancedGV → Non-Steam games (experimental)** — make sure it's on.
-2. Paste the key into **Hasheous API key (optional)** and press **Save key**. The
-   field is masked, and saving clears cached store data so games you've already
-   opened refetch with artwork.
-3. **Remove key** reverts to the keyless baseline at any time.
+2. Paste the **Client ID** and **Client Secret**, then press **Save credentials**.
+   The secret field is masked, and saving clears cached store data so games you've
+   already opened refetch with artwork.
+3. **Remove credentials** reverts to the keyless baseline at any time.
+
+The plugin exchanges the pair for an access token that lasts about 60 days,
+caches it beside its settings, and refreshes it automatically. The secret is sent
+only to `id.twitch.tv`, never placed in a URL, and never written to the log or
+reported by the diagnostic.
 
 *Checking that it worked:* open a retro game's page, then press **Test artwork
 lookup** in the same panel. It reports each stage separately, so a failure tells you
@@ -223,11 +227,12 @@ which part broke:
 | Row | ✖ means |
 | --- | --- |
 | Non-Steam sources enabled | The feature toggle above is off. |
-| API key present | Nothing saved — paste the key and press **Save key**. |
-| This game maps to IGDB | Hasheous has no IGDB link for *this* title. Not fatal: the key is then tested against a known game, so the rows below still tell you if the key is good. |
-| IGDB metadata (key accepted) | `HTTP 401`/`403` = wrong or expired key (most often the Submission key). Anything else is a network or Hasheous-side error. |
-| Screenshots listed | The key works, but IGDB has no screenshots for that title. |
-| Image address resolved | Screenshots exist but the image id couldn't be read — worth reporting. |
+| Credentials present | One or both fields are empty — the row names which. |
+| Access token from Twitch | Twitch rejected the pair. Most often the Client Type wasn't **Confidential**, or the secret was regenerated after you saved it. |
+| This game maps to IGDB | Hasheous has no IGDB link for *this* title. Not fatal: the credentials are then tested against a known game, so the rows below still tell you if they work. |
+| IGDB game fetched | `401`/`403` = token or client id rejected. `429` = over the 4 requests/second limit. |
+| Screenshots listed | Credentials work, but IGDB has no screenshots for that title. |
+| Image address resolved | Screenshots exist but carried no image id — worth reporting. |
 
 *Scope and limits:*
 
@@ -239,9 +244,9 @@ which part broke:
   ES-DE shortcut covering your whole library) has no per-game page to attach to.
 - **Images are fetched in display sizes** (a cover is ~21 KB rather than ~2.7 MB),
   so the gallery doesn't stall on a handheld connection.
-- **The key is stored locally** in the plugin's own settings file and is sent only
-  to hasheous.org. It is never included in diagnostics — **Test artwork lookup**
-  reports only whether a key is present and how long it is.
+- **Credentials are stored locally** in the plugin's own settings file. The secret
+  goes only to `id.twitch.tv`, in a form body rather than a URL, and is never
+  logged or returned by **Test artwork lookup**.
 
 ## Notes & limits
 

--- a/README.md
+++ b/README.md
@@ -184,23 +184,29 @@ genres and developers** from IGDB, add a free Hasheous **client API key** — IG
 metadata is served through Hasheous' keyed proxy, so requests without a key are
 rejected with `HTTP 401`. Images themselves are keyless.
 
-*Getting a client API key (about five minutes, free):*
+> ⚠️ **A client API key is not self-serve today.** Hasheous issues client API keys
+> *per registered application*, and creating an application is restricted to
+> Hasheous admins/moderators — on a normal account the **New** button on the Apps
+> page silently does nothing, because the request is refused server-side with no
+> message. At the time of writing only three applications exist on the whole
+> service (Gaseous, Hasheous Test Client and RomM), all of them official
+> integrations. So unless you already hold a key, **the keyless baseline is what
+> you get**, and the key field below is only useful if EnhancedGV is registered
+> with Hasheous or you have been issued a key another way.
+>
+> Tracking this: getting EnhancedGV registered as a Hasheous application is a
+> maintainer-side conversation with the Hasheous project, not something an
+> individual user can do.
 
-1. **Create a Hasheous account.** Go to <https://hasheous.org>, choose **Sign In**,
-   then **Register Account**, and confirm the verification email.
-2. **Register an app.** Open
-   <https://hasheous.org/index.html?page=dataobjects&type=app>, press **New**, and
-   give it any name you like (e.g. `EnhancedGV on my Deck`). The "app" is just the
-   thing your key is issued against.
-3. **Mint the key.** Open that app's page and find **Create Client API Key**. Enter
-   a name, leave **Expires** on **Never**, and press **Create**.
-4. **Copy it immediately.** The key is revealed once, under **Your Client API Key**.
-   If you lose it, create another — there's no way to re-read an existing one.
+*If you already have a client API key,* it is the one created under **Create Client
+API Key** on an application's page (revealed once, under *Your Client API Key*).
 
-> ⚠️ **Not the "Submission API Key."** Your profile page also shows a *Submission
-> API Key*, described as being "for your ROM manager tool". That one submits hashes
-> to Hasheous and is **rejected** by the metadata proxy. You want the **Client API
-> Key** created against an app, as above.
+> ⚠️ **It is not the "Submission API Key."** Your Hasheous profile page shows one of
+> those, described as being "for your ROM manager tool". That is a different key
+> type (`X-API-Key` rather than `X-Client-API-Key`), and the metadata proxy
+> **rejects** it with `HTTP 401`. Because IGDB *images* are un-keyed while IGDB
+> *metadata* is keyed, using the wrong key looks like "no artwork appeared" rather
+> than an error.
 
 *Entering it on the Deck:*
 

--- a/README.md
+++ b/README.md
@@ -143,6 +143,9 @@ game first so the game-specific options appear.
 - **Store language** follows your Steam client language automatically (there's no
   in-app language picker); the Status row shows the language it detected.
 - **Clear cached store data** forces a fresh fetch if anything looks stale.
+- **Updates → Beta channel (test builds)** opts in to pre-release builds. Betas
+  are GitHub pre-releases tagged `vX.Y.Z-beta` — excluded from the stable update
+  check, and superseded by the `vX.Y.Z` release when it ships.
 
 **Matching non-Steam games**
 

--- a/README.md
+++ b/README.md
@@ -171,6 +171,72 @@ while viewing the game:
 This works for regular Steam games too — you'll rarely need it, but you can point
 any game at a different store page the same way.
 
+
+**Metadata & artwork for emulated / non-Steam games**
+
+Games that have no Steam store page at all (SNES/PS1/etc. ROMs added as individual
+shortcuts) fall back to **Hasheous**, a free community game database. Turn on
+**Quick Access → EnhancedGV → Non-Steam games (experimental)**.
+
+Without a key this is the *keyless baseline*: title, description, genres,
+developer/publisher, platform and a logo. To also get **cover art, screenshots,
+genres and developers** from IGDB, add a free Hasheous **client API key** — IGDB
+metadata is served through Hasheous' keyed proxy, so requests without a key are
+rejected with `HTTP 401`. Images themselves are keyless.
+
+*Getting a client API key (about five minutes, free):*
+
+1. **Create a Hasheous account.** Go to <https://hasheous.org>, choose **Sign In**,
+   then **Register Account**, and confirm the verification email.
+2. **Register an app.** Open
+   <https://hasheous.org/index.html?page=dataobjects&type=app>, press **New**, and
+   give it any name you like (e.g. `EnhancedGV on my Deck`). The "app" is just the
+   thing your key is issued against.
+3. **Mint the key.** Open that app's page and find **Create Client API Key**. Enter
+   a name, leave **Expires** on **Never**, and press **Create**.
+4. **Copy it immediately.** The key is revealed once, under **Your Client API Key**.
+   If you lose it, create another — there's no way to re-read an existing one.
+
+> ⚠️ **Not the "Submission API Key."** Your profile page also shows a *Submission
+> API Key*, described as being "for your ROM manager tool". That one submits hashes
+> to Hasheous and is **rejected** by the metadata proxy. You want the **Client API
+> Key** created against an app, as above.
+
+*Entering it on the Deck:*
+
+1. **Quick Access → EnhancedGV → Non-Steam games (experimental)** — make sure it's on.
+2. Paste the key into **Hasheous API key (optional)** and press **Save key**. The
+   field is masked, and saving clears cached store data so games you've already
+   opened refetch with artwork.
+3. **Remove key** reverts to the keyless baseline at any time.
+
+*Checking that it worked:* open a retro game's page, then press **Test artwork
+lookup** in the same panel. It reports each stage separately, so a failure tells you
+which part broke:
+
+| Row | ✖ means |
+| --- | --- |
+| Non-Steam sources enabled | The feature toggle above is off. |
+| API key present | Nothing saved — paste the key and press **Save key**. |
+| This game maps to IGDB | Hasheous has no IGDB link for *this* title. Not fatal: the key is then tested against a known game, so the rows below still tell you if the key is good. |
+| IGDB metadata (key accepted) | `HTTP 401`/`403` = wrong or expired key (most often the Submission key). Anything else is a network or Hasheous-side error. |
+| Screenshots listed | The key works, but IGDB has no screenshots for that title. |
+| Image address resolved | Screenshots exist but the image id couldn't be read — worth reporting. |
+
+*Scope and limits:*
+
+- **Steam games are untouched.** This only affects games matched to a non-Steam
+  source; a game that genuinely exists on Steam always uses the Steam store page.
+- **No trailers.** IGDB supplies YouTube ids rather than playable video URLs, so the
+  video gallery stays Steam-only.
+- **Per-game shortcuts only.** A single emulator/frontend entry (one RetroDeck or
+  ES-DE shortcut covering your whole library) has no per-game page to attach to.
+- **Images are fetched in display sizes** (a cover is ~21 KB rather than ~2.7 MB),
+  so the gallery doesn't stall on a handheld connection.
+- **The key is stored locally** in the plugin's own settings file and is sent only
+  to hasheous.org. It is never included in diagnostics — **Test artwork lookup**
+  reports only whether a key is present and how long it is.
+
 ## Notes & limits
 
 - **Plays nicely with other plugins.** EnhancedGV never patches Steam's render

--- a/README.md
+++ b/README.md
@@ -144,8 +144,9 @@ game first so the game-specific options appear.
   in-app language picker); the Status row shows the language it detected.
 - **Clear cached store data** forces a fresh fetch if anything looks stale.
 - **Updates → Beta channel (test builds)** opts in to pre-release builds. Betas
-  are GitHub pre-releases tagged `vX.Y.Z-beta` — excluded from the stable update
-  check, and superseded by the `vX.Y.Z` release when it ships.
+  are GitHub pre-releases tagged `vX.Y.Z-beta.N` (a new number per cut) —
+  excluded from the stable update check, and retired when the `vX.Y.Z` release
+  ships.
 
 **Matching non-Steam games**
 

--- a/README.md
+++ b/README.md
@@ -60,7 +60,9 @@ Access** panel.
 - **Backend** (`main.py`, Python stdlib only): fetches from Steam's store/web
   APIs (bypassing the browser's CORS restrictions), **normalizes and
   allowlist-sanitizes** the HTML/JSON, converts news BBCODE → safe HTML, resolves
-  non-Steam games to a store appid by title search, and caches responses to disk
+  non-Steam games to a store appid by title search, enriches non-Steam matches
+  with IGDB artwork when a Hasheous API key is set (metadata via the keyed
+  proxy; images from IGDB's public CDN in display sizes), and caches responses to disk
   (`DECKY_PLUGIN_RUNTIME_DIR`) with per-kind TTLs plus negative caching and
   in-flight de-duplication to stay well under Steam's rate limits. Expired
   entries are served **stale-while-revalidate** — the last known-good copy is

--- a/main.py
+++ b/main.py
@@ -196,6 +196,13 @@ _SSL_UNVERIFIED = ssl._create_unverified_context()
 # Ceiling on any JSON body we will buffer. The store and provider payloads are
 # tens of KB; anything near this is a hostile or broken upstream.
 MAX_RESPONSE_BYTES = 8 * 1024 * 1024
+# Ceiling on one HTML field handed to the sanitizer.
+MAX_SANITIZE_BYTES = 512 * 1024
+# Caps on the Hasheous hash-lookup walk: one panel open must not become an
+# unbounded request series driven by whatever that search returned.
+HASHEOUS_MAX_GAMES = 8
+HASHEOUS_MAX_ROMS = 8
+HASHEOUS_MAX_LOOKUPS = 24
 
 
 class _NoRedirect(urllib.request.HTTPRedirectHandler):
@@ -559,21 +566,77 @@ def _github_url(u) -> str:
     return u if parts.hostname.lower() in _GITHUB_HOSTS else ""
 
 
+_SCHEME_RE = re.compile(r"[a-zA-Z][a-zA-Z0-9+.\-]*:")
+
+
 def _safe_url(u) -> str:
     """Only allow http(s) (and protocol-relative / relative / anchor) URLs in
     HTML rendered via dangerouslySetInnerHTML; neutralize javascript:/data:/
-    vbscript:/etc. Decodes entities and strips control chars first so tricks
-    like `java&#09;script:` or leading whitespace can't smuggle a scheme."""
-    u = html.unescape(str(u or "")).strip()
+    vbscript:/etc.
+
+    DOES NOT ESCAPE QUOTES. Every caller that interpolates the result into an
+    attribute MUST wrap it in html.escape(..., quote=True) — see _filter_attrs
+    and _bbcode_to_html.
+
+    Two bugs this has had, both fixed here and covered by tests:
+      * ONE unescape pass let `&amp;#106;avascript:` survive as `&#106;...`,
+        which the browser then decodes back to `javascript:`. Now unescaped to a
+        fixed point.
+      * The scheme was derived by splitting on "#" FIRST. Every numeric
+        character reference starts with "#", so a single entity truncated the
+        string before the colon and the "no colon means relative" branch
+        returned a live javascript: URL verbatim. The scheme is now matched
+        directly, and any leftover "&" is treated as hostile.
+    """
+    u = str(u or "")
+    for _ in range(8):                      # collapse &amp;#106; -> &#106; -> j
+        nxt = html.unescape(u)
+        if nxt == u:
+            break
+        u = nxt
+    u = u.strip()
     u = "".join(ch for ch in u if ord(ch) >= 0x20)  # drop TAB/NEWLINE/etc.
     low = u.lower()
     if low.startswith(("http://", "https://", "//", "/", "#", "mailto:")):
         return u
-    # Relative path with no scheme (no colon before the first / ? #) is safe.
-    scheme = low.split("/", 1)[0].split("?", 1)[0].split("#", 1)[0]
-    if ":" not in scheme:
-        return u
-    return "#"
+    # Anything carrying a scheme, or an entity we could not resolve, is refused.
+    if _SCHEME_RE.match(low) or "&" in u:
+        return "#"
+    return u
+
+
+def _steam_media_url(u) -> str:
+    """A media URL, or "" unless it is https on a Steam CDN host.
+
+    Every legitimate value here is a steamstatic.com URL. These strings are
+    fetched by the frontend (the DASH manifest is fetched and its segment paths
+    are resolved relative to it) and a movie with no progressive sources
+    AUTO-PLAYS on page open — so an appdetails response that names an arbitrary
+    host gets a request series with no user interaction.
+    """
+    try:
+        parts = urllib.parse.urlsplit(str(u or "").strip())
+    except Exception:
+        return ""
+    host = (parts.hostname or "").lower()
+    if parts.scheme != "https":
+        return ""
+    return u if host == "steamstatic.com" or host.endswith(".steamstatic.com") else ""
+
+
+def _safe_ext_url(u) -> str:
+    """A URL fit to hand to the Steam client's external browser.
+
+    Stricter than _safe_url on purpose: that one deliberately permits
+    protocol-relative, root-relative, anchor and mailto: forms because it guards
+    hrefs INSIDE our own HTML. A navigation target must be an absolute http(s)
+    URL — `steam://` in particular is a live command channel to the Steam client.
+    """
+    try:
+        parts = urllib.parse.urlsplit(_safe_url(u))
+    except Exception:
+        return ""
+    return parts.geturl() if parts.scheme in ("http", "https") and parts.netloc else ""
 
 
 # Allowlist HTML sanitizer — replaces the previous regex denylist, which had
@@ -737,9 +800,18 @@ _TOKEN_RE = re.compile(
     r"|<!\[CDATA\[.*?\]\]>"                              # cdata
     r"|<![^>]*>"                                         # doctype/declaration
     r"|<\s*/\s*([a-zA-Z][a-zA-Z0-9]*)\s*>"              # end tag        -> grp1
-    r"|<\s*([a-zA-Z][a-zA-Z0-9]*)((?:\s+[^<>]*?)?)\s*(/?)\s*>",  # start -> grp2/3/4
+    r"|<\s*([a-zA-Z][a-zA-Z0-9]*)([^<>]*)>",             # start tag     -> grp2/3
     re.S,
 )
+# The start-tag branch used to read `((?:\s+[^<>]*?)?)\s*(/?)\s*>`: three
+# quantifiers that all match whitespace, overlapping on the same run. On a
+# `<`+letter followed by spaces that never reach `>`, the engine tries every
+# partition of that run before failing — `"<a" + " "*800` measured at 48.8s on a
+# developer machine, and this is the sanitizer that actually runs on the
+# handheld (SteamOS's Python has no html.parser). It is fed Steam's
+# about_the_game and Hasheous descriptions, on the event loop, so one hostile
+# field froze every RPC. One greedy non-overlapping class matches linearly; the
+# self-closing slash is now read off the end of the attribute span instead.
 _ATTR_RE = re.compile(
     r"([a-zA-Z_:][-a-zA-Z0-9_:.]*)"                     # name
     r"(?:\s*=\s*(\"[^\"]*\"|'[^']*'|[^\s\"'>]+))?"      # optional value
@@ -795,8 +867,12 @@ def _sanitize_html_regex(raw: str) -> str:
             tag = start_name.lower()
             if tag not in _ALLOWED_TAGS:
                 continue  # drop tag; inner text still flows through as text
-            out.append(f"<{tag}{_filter_attrs(_parse_attrs(m.group(3)))}>")
-            if tag not in _VOID_TAGS and m.group(4) != "/":
+            attrs = m.group(3) or ""
+            self_closing = attrs.rstrip().endswith("/")
+            if self_closing:
+                attrs = attrs.rstrip()[:-1]
+            out.append(f"<{tag}{_filter_attrs(_parse_attrs(attrs))}>")
+            if tag not in _VOID_TAGS and not self_closing:
                 open_stack.append(tag)
         # comments / cdata / doctype -> dropped entirely
     if pos < len(raw):
@@ -845,6 +921,10 @@ def _sanitize_html(raw) -> str:
     global SANITIZER_ENGINE
     if not raw or not isinstance(raw, str):
         return ""
+    if len(raw) > MAX_SANITIZE_BYTES:
+        # Real store descriptions are a few KB. Truncate rather than hand an
+        # unbounded field to the tokenizer.
+        raw = raw[:MAX_SANITIZE_BYTES]
     if _HAVE_HTMLPARSER:
         try:
             p = _Sanitizer()
@@ -877,7 +957,9 @@ def _bbcode_to_html(text) -> str:
     HTML subset. Unknown tags are dropped rather than shown raw."""
     if not text or not isinstance(text, str):
         return ""
-    t = _expand_clan_images(text)
+    # A literal NUL from upstream would forge one of our own placeholder tokens
+    # after the escape pass, so it never gets to exist.
+    t = _expand_clan_images(text.replace("\x00", ""))
 
     # Images first (before we escape), capture the URL.
     t = re.sub(r"\[img\](.*?)\[/img\]",
@@ -895,11 +977,18 @@ def _bbcode_to_html(text) -> str:
     t = html.escape(t)
 
     # Restore the tokens we set aside, as real (safe) HTML.
+    # html.escape(..., quote=True) is NOT optional here. The URL was stashed as a
+    # token BEFORE the escape pass above, so it never went through it, and
+    # _safe_url only filters the scheme — it happily returns a value containing a
+    # double quote. Without this, [img]https://x/p.png" onerror="…[/img] breaks
+    # straight out of the attribute and runs in the Steam UI.
     t = t.replace("\x00/A\x00", "</a>")
     t = re.sub(r"\x00A\x00(.*?)\x00",
-               lambda m: f'<a href="{_safe_url(m.group(1))}" target="_blank" rel="noreferrer">', t)
+               lambda m: '<a href="%s" target="_blank" rel="noreferrer">'
+                         % html.escape(_safe_url(m.group(1)), quote=True), t)
     t = re.sub(r"\x00IMG\x00(.*?)\x00",
-               lambda m: f'<img src="{_safe_url(m.group(1))}" style="max-width:100%;border-radius:4px;" />', t)
+               lambda m: '<img src="%s" style="max-width:100%%;border-radius:4px;" />'
+                         % html.escape(_safe_url(m.group(1)), quote=True), t)
 
     # Block/inline formatting tags -> HTML.
     replacements = [
@@ -970,10 +1059,10 @@ def _derive_movie_sources(movie: dict) -> dict:
     return {
         "id": movie.get("id"),
         "name": movie.get("name", ""),
-        "thumb": thumb,
-        "sources": candidates,
-        "hls": movie.get("hls_h264"),
-        "dash": movie.get("dash_av1") or movie.get("dash_h264"),
+        "thumb": _steam_media_url(thumb),
+        "sources": [c for c in (_steam_media_url(c) for c in candidates) if c],
+        "hls": _steam_media_url(movie.get("hls_h264")),
+        "dash": _steam_media_url(movie.get("dash_av1") or movie.get("dash_h264")),
     }
 
 
@@ -1001,7 +1090,7 @@ def _normalize_appdetails(data: dict) -> dict:
     meta = data.get("metacritic")
     metacritic = None
     if isinstance(meta, dict) and meta.get("score") is not None:
-        metacritic = {"score": meta.get("score"), "url": meta.get("url", "")}
+        metacritic = {"score": meta.get("score"), "url": _safe_ext_url(meta.get("url", ""))}
 
     rd = data.get("release_date") or {}
 
@@ -1078,9 +1167,9 @@ def _normalize_news(data: dict) -> dict:
         items.append({
             "gid": n.get("gid"),
             "title": n.get("title", ""),
-            "html": _bbcode_to_html(n.get("contents", "")),
+            "html": _sanitize_html(_bbcode_to_html(n.get("contents", ""))),
             "date": n.get("date"),
-            "url": n.get("url", ""),
+            "url": _safe_ext_url(n.get("url", "")),
             "external": bool(n.get("is_external_url")),
             "feedlabel": n.get("feedlabel", ""),
             "author": n.get("author", ""),
@@ -1716,12 +1805,24 @@ class Plugin:
             return {"ok": False, "error": "no hasheous match"}
         nt = _norm_title(title)
         ranked = [g for g in games if _norm_title(g.get("name")) == nt] or games
-        for g in ranked:
-            for rom in (g.get("roms") or []):
+        # The response is upstream-controlled, and every (rom, algorithm) pair
+        # becomes its own sequential 15s-timeout request. Unclamped, a hostile or
+        # broken search result (8 games x thousands of roms x 3 algorithms) turns
+        # one panel open into tens of thousands of requests at a third party,
+        # holding an executor thread the whole time. Bound the whole walk.
+        attempts = 0
+        for g in ranked[:HASHEOUS_MAX_GAMES]:
+            for rom in (g.get("roms") or [])[:HASHEOUS_MAX_ROMS]:
                 for alg in ("sha1", "md5", "crc"):
                     hv = rom.get(alg)
                     if not hv:
                         continue
+                    if attempts >= HASHEOUS_MAX_LOOKUPS:
+                        decky.logger.warning(
+                            "hasheous: lookup budget spent (%d); giving up on %r",
+                            HASHEOUS_MAX_LOOKUPS, title)
+                        return {"ok": False, "error": "no resolvable rom hash"}
+                    attempts += 1
                     try:
                         res = await self._hasheous_lookup_hash(alg, hv)
                     except Exception:

--- a/main.py
+++ b/main.py
@@ -33,6 +33,8 @@ SETTINGS_FILE = os.path.join(SETTINGS_DIR, "settings.json")
 # Per-game store-appid matches (device-local). Lives in SETTINGS_DIR (NOT the
 # cache dir) so it survives updates and is never wiped by _purge_stale_cache.
 MATCHES_FILE = os.path.join(SETTINGS_DIR, "matches.json")
+# IGDB app access token cache (derived state, not a preference).
+IGDB_TOKEN_FILE = os.path.join(SETTINGS_DIR, "igdb_token.json")
 
 # Bump when fetch/cache behavior changes so an update auto-clears stale cache
 # (e.g. old negative-cached SSL failures) instead of serving it after a fix.
@@ -94,26 +96,58 @@ CLAN_IMAGE_BASE = "https://clan.akamai.steamstatic.com/images"
 #   -> DataObjects/Game/{id} (name, AIDescription, Logo, Tags, publisher, IGDB id)
 # The rich IGDB proxy (cover/screenshots/genres) is key-gated (a later, opt-in
 # phase); this baseline is entirely keyless and works with the feature toggled on.
-# --- IGDB enrichment (opt-in, needs a Hasheous CLIENT API key) --------------- #
-# Hasheous proxies IGDB at /MetadataProxy/IGDB/*. Verified against the live
-# OpenAPI spec and by probing the running service:
-#   * METADATA is key-gated: /MetadataProxy/IGDB/Game?Id=… answers 401 without an
-#     `X-Client-API-Key` header (securityScheme "Client API Key").
-#   * IMAGES are NOT key-gated: /MetadataProxy/IGDB/Image/{hash}.jpg answers 200
-#     with no key — but it serves the ORIGINAL (a cover measured at 2.7 MB), and
-#     it takes no size parameter (a t_cover_big-style path 404s).
-# So metadata goes through the proxy with the key, and image URLs point at IGDB's
-# own public CDN, which does serve sized renditions keylessly. Measured on the
-# same cover: t_thumb 3 KB / t_cover_big 21 KB / t_screenshot_med 40 KB /
-# t_1080p 163 KB, versus 2.7 MB from the proxy. On a Deck over wifi, with a
-# thumbnail strip of a dozen shots, that difference is the whole feature.
+# --- IGDB enrichment (opt-in, needs free IGDB/Twitch credentials) ----------- #
+# We talk to IGDB DIRECTLY, not through Hasheous' proxy. Hasheous does proxy IGDB
+# at /MetadataProxy/IGDB/*, but every metadata endpoint there is declared
+# `security: [Client API Key]`, and those client keys are issued per REGISTERED
+# APPLICATION — creating one is restricted to Hasheous admins/moderators (three
+# applications exist service-wide, all official integrations). So that route is
+# closed to ordinary users, however free it looks.
+#
+# IGDB's own API is free and genuinely self-serve: a Twitch account with 2FA,
+# an application registered in the Twitch Developer Portal (Client Type
+# "Confidential"), and a generated Client Secret. Verified against the live
+# services:
+#   * POST https://id.twitch.tv/oauth2/token (form-encoded client_id /
+#     client_secret / grant_type=client_credentials) answers
+#     {"status":400,"message":"invalid client"} for bad credentials — the
+#     standard OAuth2 client-credentials grant. Form body, not query string, so
+#     the secret never lands in a URL or a proxy log.
+#   * POST https://api.igdb.com/v4/<endpoint> requires BOTH a `Client-ID` header
+#     and `Authorization: Bearer <app access token>`; without them it answers
+#     401 with a tips payload naming exactly those two headers.
+#   * Rate limit is 4 requests/second, 8 concurrent (documented).
+#
+# Hasheous is still what MATCHES a ROM to a game, keylessly, and its record
+# carries the IGDB id — so the expensive half of this feature needs no key at
+# all, and IGDB only supplies artwork on top.
+#
+# Field expansion (`fields cover.image_id,genres.name;`) means ONE request per
+# game instead of the proxy's one-request-per-image-id fan-out.
+#
+# Images stay on IGDB's public CDN, which is keyless and serves sized
+# renditions. Measured on one cover: t_thumb 3 KB / t_cover_big 21 KB /
+# t_screenshot_med 40 KB / t_1080p 163 KB, versus 2.7 MB for the original. On a
+# Deck over wifi, with a strip of a dozen shots, that difference is the feature.
+IGDB_API = "https://api.igdb.com/v4"
+IGDB_TOKEN_URL = "https://id.twitch.tv/oauth2/token"
 IGDB_IMG_CDN = "https://images.igdb.com/igdb/image/upload"
 IGDB_SIZE_COVER = "t_cover_big"
 IGDB_SIZE_THUMB = "t_screenshot_med"
 IGDB_SIZE_FULL = "t_1080p"
-# Screenshot/artwork metadata is one request PER image id, so cap how many we
-# resolve: enough to fill the carousel, few enough to stay polite and quick.
+# How many screenshots/artworks to carry into the gallery.
 IGDB_MAX_SHOTS = 12
+# One expanded query covers everything the panel needs.
+IGDB_GAME_FIELDS = (
+    "fields name,summary,url,"
+    "cover.image_id,"
+    "screenshots.image_id,"
+    "artworks.image_id,"
+    "genres.name,"
+    "involved_companies.developer,"
+    "involved_companies.publisher,"
+    "involved_companies.company.name;"
+)
 
 HASHEOUS_BASE = "https://hasheous.org/api/v1"
 HASHEOUS_IMAGE = HASHEOUS_BASE + "/Images/"  # + {image_hash}
@@ -287,14 +321,87 @@ def _feature_non_steam() -> bool:
         return False
 
 
-def _igdb_key() -> str:
-    """The Hasheous CLIENT API key, or "" when enrichment is off. Read from the
-    settings file for the same reason as _feature_non_steam. NEVER logged."""
+def _igdb_creds():
+    """(client_id, client_secret) for IGDB, or ("", "") when not configured.
+
+    Read from the settings file for the same reason as _feature_non_steam. The
+    SECRET is never logged, never returned to the frontend, and never placed in
+    a URL.
+    """
     try:
         with open(SETTINGS_FILE, "r", encoding="utf-8") as fh:
-            return str(json.load(fh).get("hasheousApiKey", "") or "").strip()
+            saved = json.load(fh)
+        return (str(saved.get("igdbClientId", "") or "").strip(),
+                str(saved.get("igdbClientSecret", "") or "").strip())
     except Exception:
-        return ""
+        return ("", "")
+
+
+def _igdb_token_sync(client_id: str, client_secret: str) -> str:
+    """An IGDB app access token, from cache when still valid.
+
+    Twitch's client-credentials tokens last ~60 days, so minting one per request
+    would be both slow and rude. The token is cached beside the settings file
+    (not IN it: settings are read and rewritten by the frontend, and a token is
+    derived state, not a preference) and refreshed once inside a 10-minute
+    safety margin. Sent as a form body so the secret never reaches a URL.
+    """
+    now = time.time()
+    try:
+        with open(IGDB_TOKEN_FILE, "r", encoding="utf-8") as fh:
+            tok = json.load(fh)
+        if (tok.get("client_id") == client_id
+                and float(tok.get("expires_at", 0)) - 600 > now
+                and tok.get("access_token")):
+            return str(tok["access_token"])
+    except Exception:
+        pass
+
+    body = urllib.parse.urlencode({
+        "client_id": client_id,
+        "client_secret": client_secret,
+        "grant_type": "client_credentials",
+    }).encode("ascii")
+    req = urllib.request.Request(
+        IGDB_TOKEN_URL, data=body, method="POST",
+        headers={"User-Agent": USER_AGENT,
+                 "Content-Type": "application/x-www-form-urlencoded",
+                 "Accept": "application/json"})
+    with urllib.request.urlopen(req, timeout=REQUEST_TIMEOUT, context=_SSL_CTX) as resp:
+        got = json.loads(resp.read().decode("utf-8", "replace"))
+
+    token = str(got.get("access_token") or "")
+    if not token:
+        raise RuntimeError("no access_token in the token response")
+    try:
+        os.makedirs(SETTINGS_DIR, exist_ok=True)
+        with open(IGDB_TOKEN_FILE, "w", encoding="utf-8") as fh:
+            json.dump({"client_id": client_id, "access_token": token,
+                       "expires_at": now + float(got.get("expires_in") or 0)}, fh)
+        os.chmod(IGDB_TOKEN_FILE, 0o600)
+    except Exception:
+        pass  # a token we cannot cache still works for this request
+    return token
+
+
+def _igdb_forget_token() -> None:
+    """Drop the cached token — called when the credentials change."""
+    try:
+        os.remove(IGDB_TOKEN_FILE)
+    except Exception:
+        pass
+
+
+def _igdb_post_sync(endpoint: str, body: str, client_id: str, token: str):
+    """One POST against IGDB v4. Returns the decoded list (IGDB always answers
+    with an array). Apicalypse bodies are plain text, not JSON."""
+    req = urllib.request.Request(
+        f"{IGDB_API}/{endpoint}", data=body.encode("utf-8"), method="POST",
+        headers={"User-Agent": USER_AGENT, "Accept": "application/json",
+                 "Content-Type": "text/plain",
+                 "Client-ID": client_id, "Authorization": f"Bearer {token}"})
+    with urllib.request.urlopen(req, timeout=REQUEST_TIMEOUT, context=_SSL_CTX) as resp:
+        return json.loads(resp.read().decode("utf-8", "replace"))
 
 
 def _igdb_img(image_hash: str, size: str) -> str:
@@ -1565,39 +1672,27 @@ class Plugin:
         return {"ok": False, "error": "no resolvable rom hash"}
 
     # --- IGDB enrichment (opt-in; needs a Hasheous client API key) --------- #
-    async def _igdb_get(self, path: str, params: dict, key: str):
-        """One keyed GET against the IGDB metadata proxy."""
-        url = f"{HASHEOUS_BASE}/MetadataProxy/IGDB/{path}?" + urllib.parse.urlencode(params)
+    async def _igdb_token(self, client_id: str, client_secret: str) -> str:
         loop = asyncio.get_running_loop()
         return await loop.run_in_executor(
-            None, functools.partial(_http_get_json, url, {"X-Client-API-Key": key})
-        )
+            None, functools.partial(_igdb_token_sync, client_id, client_secret))
 
-    async def _igdb_image_hash(self, kind: str, image_id, key: str):
-        """Resolve one Cover/Screenshot/Artwork id to its IGDB image hash."""
-        try:
-            obj = await self._igdb_get(kind, {"Id": int(image_id)}, key)
-        except Exception:
-            return None
-        return _igdb_pick(obj, "image_id", "imageId", "hash")
+    async def _igdb_game(self, igdb_id: int, client_id: str, token: str):
+        """The one expanded request that backs the whole enrichment.
 
-    async def _igdb_names(self, kind: str, ids, key: str, limit: int = 12):
-        """Resolve a list of ids (Genre, Company, …) to their display names."""
-        out = []
-        for chunk in [list(ids)[:limit]]:
-            got = await asyncio.gather(
-                *[self._igdb_get(kind, {"Id": int(i)}, key) for i in chunk],
-                return_exceptions=True,
-            )
-            for o in got:
-                if isinstance(o, BaseException):
-                    continue
-                n = _igdb_pick(o, "name")
-                if n:
-                    out.append(str(n))
-        return out
+        Field expansion resolves covers, screenshots, artworks, genres and
+        companies inline, so this replaces the proxy-era fan-out of one request
+        per image id. IGDB answers with an array; we want its single element.
+        """
+        body = f"{IGDB_GAME_FIELDS} where id = {int(igdb_id)}; limit 1;"
+        loop = asyncio.get_running_loop()
+        got = await loop.run_in_executor(
+            None, functools.partial(_igdb_post_sync, "games", body, client_id, token))
+        if isinstance(got, list) and got and isinstance(got[0], dict):
+            return got[0]
+        return None
 
-    async def _igdb_delta(self, igdb_id: int, key: str) -> dict:
+    async def _igdb_delta(self, igdb_id: int, client_id: str, token: str) -> dict:
         """Fetch the IGDB-derived fields for a game. CACHED ON ITS OWN — never
         cache the merged result: the merge depends on what the Hasheous baseline
         already had, so a cached merge made against one baseline would be served
@@ -1607,9 +1702,10 @@ class Plugin:
             return cached
 
         try:
-            game = await self._igdb_get("Game", {"Id": int(igdb_id)}, key)
+            game = await self._igdb_game(int(igdb_id), client_id, token)
         except urllib.error.HTTPError as exc:
-            # 401/403 = missing/rejected key. Logged without the key itself.
+            # 401/403 = rejected credentials, 429 = over the 4 req/s limit.
+            # Logged without the credentials themselves.
             decky.logger.error(f"igdb: HTTP {exc.code} for game {igdb_id}")
             return {}
         except Exception as exc:
@@ -1620,66 +1716,49 @@ class Plugin:
 
         delta = {}
 
-        cover_id = _igdb_pick(game, "cover")
-        if cover_id:
-            h = await self._igdb_image_hash("Cover", cover_id, key)
-            if h:
-                delta["header_image"] = _igdb_img(h, IGDB_SIZE_COVER)
+        # Expanded objects: cover/screenshots/artworks arrive as dicts carrying
+        # image_id, so no follow-up request is needed to resolve any of them.
+        cover_hash = _igdb_pick(_igdb_pick(game, "cover") or {}, "image_id")
+        if cover_hash:
+            url = _igdb_img(cover_hash, IGDB_SIZE_COVER)
+            if url:
+                delta["header_image"] = url
 
         # Screenshots (+ artworks as filler) — the media hero is the whole point
         # of this phase; the keyless baseline has none.
-        pairs = ([("Screenshot", i) for i in (_igdb_pick(game, "screenshots") or [])] +
-                 [("Artwork", i) for i in (_igdb_pick(game, "artworks") or [])])[:IGDB_MAX_SHOTS]
         shots = []
-        if pairs:
-            hashes = await asyncio.gather(
-                *[self._igdb_image_hash(k, i, key) for k, i in pairs],
-                return_exceptions=True,
-            )
-            for (_kind, ident), h in zip(pairs, hashes):
-                if isinstance(h, BaseException) or not h:
-                    continue
-                shots.append({"id": int(ident),
-                              "thumb": _igdb_img(h, IGDB_SIZE_THUMB),
-                              "full": _igdb_img(h, IGDB_SIZE_FULL)})
+        for obj in (list(_igdb_pick(game, "screenshots") or [])
+                    + list(_igdb_pick(game, "artworks") or [])):
+            if len(shots) >= IGDB_MAX_SHOTS:
+                break
+            h = _igdb_pick(obj, "image_id") if isinstance(obj, dict) else None
+            thumb, full = _igdb_img(h, IGDB_SIZE_THUMB), _igdb_img(h, IGDB_SIZE_FULL)
+            if thumb and full:
+                shots.append({"id": int(_igdb_pick(obj, "id") or len(shots)),
+                              "thumb": thumb, "full": full})
         if shots:
             delta["screenshots"] = shots
 
-        gids = list(_igdb_pick(game, "genres") or [])
-        if gids:
-            names = await self._igdb_names("Genre", gids, key)
-            if names:
-                delta["genres"] = [{"id": n, "description": n} for n in names]
+        names = [str(_igdb_pick(g, "name")) for g in (_igdb_pick(game, "genres") or [])
+                 if isinstance(g, dict) and _igdb_pick(g, "name")]
+        if names:
+            delta["genres"] = [{"id": n, "description": n} for n in names]
 
-        ic_ids = list(_igdb_pick(game, "involved_companies") or [])
-        if ic_ids:
-            devs, pubs = [], []
-            got = await asyncio.gather(
-                *[self._igdb_get("InvolvedCompany", {"Id": int(i)}, key)
-                  for i in ic_ids[:8]],
-                return_exceptions=True,
-            )
-            for ic in got:
-                if isinstance(ic, BaseException) or not isinstance(ic, dict):
-                    continue
-                cid = _igdb_pick(ic, "company")
-                if not cid:
-                    continue
-                try:
-                    comp = await self._igdb_get("Company", {"Id": int(cid)}, key)
-                except Exception:
-                    continue
-                nm = _igdb_pick(comp, "name")
-                if not nm:
-                    continue
-                if _igdb_pick(ic, "developer"):
-                    devs.append(str(nm))
-                elif _igdb_pick(ic, "publisher"):
-                    pubs.append(str(nm))
-            if devs:
-                delta["developers"] = devs
-            if pubs:
-                delta["publishers"] = pubs
+        devs, pubs = [], []
+        for ic in (_igdb_pick(game, "involved_companies") or []):
+            if not isinstance(ic, dict):
+                continue
+            nm = _igdb_pick(_igdb_pick(ic, "company") or {}, "name")
+            if not nm:
+                continue
+            if _igdb_pick(ic, "developer"):
+                devs.append(str(nm))
+            elif _igdb_pick(ic, "publisher"):
+                pubs.append(str(nm))
+        if devs:
+            delta["developers"] = devs
+        if pubs:
+            delta["publishers"] = pubs
 
         summary = _igdb_pick(game, "summary")
         if summary:
@@ -1698,15 +1777,20 @@ class Plugin:
     async def _igdb_enrich(self, igdb_id: int, base: dict) -> dict:
         """Layer IGDB artwork/details onto a normalized Hasheous AppDetails.
 
-        Best-effort throughout: a bad key, a rate limit or an unexpected shape
-        degrades to the keyless baseline rather than blanking the panel. Hasheous
+        Best-effort throughout: bad credentials, a rate limit or an unexpected
+        shape degrades to the keyless baseline rather than blanking the panel. Hasheous
         data WINS wherever it has some — IGDB only fills what was empty. The one
         exception is `screenshots`, which the baseline can never populate.
         """
-        key = _igdb_key()
-        if not key or not igdb_id:
+        client_id, client_secret = _igdb_creds()
+        if not (client_id and client_secret and igdb_id):
             return base
-        delta = await self._igdb_delta(int(igdb_id), key)
+        try:
+            token = await self._igdb_token(client_id, client_secret)
+        except Exception as exc:
+            decky.logger.error(f"igdb: could not obtain an access token: {exc}")
+            return base
+        delta = await self._igdb_delta(int(igdb_id), client_id, token)
         if not delta:
             return base
 
@@ -1728,10 +1812,10 @@ class Plugin:
         return out
 
     async def test_igdb(self, game_appid=0):
-        """Per-step IGDB probe for the QAM, so a beta tester can see exactly
-        where enrichment stops instead of just 'no artwork appeared'. Never
-        returns the key itself — only whether one is set and how long it is."""
-        key = _igdb_key()
+        """Per-step IGDB probe for the QAM, so a tester can see exactly where
+        enrichment stops instead of just 'no artwork appeared'. Never returns the
+        credentials — only whether they are set, and the client id's length."""
+        client_id, client_secret = _igdb_creds()
         steps = []
 
         def step(name, ok, detail=""):
@@ -1739,9 +1823,26 @@ class Plugin:
 
         step("Non-Steam sources enabled", _feature_non_steam(),
              "on" if _feature_non_steam() else "turn it on above")
-        step("API key present", bool(key), f"{len(key)} chars" if key else "no key saved")
-        if not key:
-            return {"ok": False, "steps": steps, "error": "no API key"}
+        step("Credentials present", bool(client_id and client_secret),
+             ("client id + secret saved" if client_id and client_secret else
+              "missing " + (" and ".join(
+                  ([] if client_id else ["Client ID"])
+                  + ([] if client_secret else ["Client Secret"])))))
+        if not (client_id and client_secret):
+            return {"ok": False, "steps": steps, "error": "no IGDB credentials"}
+
+        try:
+            token = await self._igdb_token(client_id, client_secret)
+            step("Access token from Twitch", bool(token), "token obtained")
+        except urllib.error.HTTPError as exc:
+            detail = f"HTTP {exc.code}"
+            if exc.code in (400, 401, 403):
+                detail += " — Twitch rejected the client id/secret pair"
+            step("Access token from Twitch", False, detail)
+            return {"ok": False, "steps": steps, "error": detail}
+        except Exception as exc:
+            step("Access token from Twitch", False, str(exc))
+            return {"ok": False, "steps": steps, "error": str(exc)}
 
         # Which game? The one on screen if it resolves to Hasheous, else a known
         # public mapping (Super Metroid) so the key itself can still be tested.
@@ -1766,27 +1867,32 @@ class Plugin:
         else:
             igdb_id, label = 1103, "Super Metroid (fallback probe)"
             step("This game maps to IGDB", False,
-                 "no IGDB mapping for this game; testing the key against a known title")
+                 "no IGDB mapping for this game; testing the credentials against a known title")
 
         try:
-            game = await self._igdb_get("Game", {"Id": igdb_id}, key)
-            step("IGDB metadata (key accepted)", isinstance(game, dict),
-                 _igdb_pick(game, "name") or "no name field")
+            game = await self._igdb_game(igdb_id, client_id, token)
+            step("IGDB game fetched", isinstance(game, dict),
+                 _igdb_pick(game, "name") if isinstance(game, dict)
+                 else "no game returned for that id")
         except urllib.error.HTTPError as exc:
-            step("IGDB metadata (key accepted)", False,
-                 f"HTTP {exc.code}" + (" — key rejected" if exc.code in (401, 403) else ""))
-            return {"ok": False, "steps": steps, "error": f"HTTP {exc.code}"}
+            detail = f"HTTP {exc.code}"
+            if exc.code in (401, 403):
+                detail += " — IGDB rejected the token or client id"
+            elif exc.code == 429:
+                detail += " — over the 4 requests/second limit"
+            step("IGDB game fetched", False, detail)
+            return {"ok": False, "steps": steps, "error": detail}
         except Exception as exc:
-            step("IGDB metadata (key accepted)", False, str(exc))
+            step("IGDB game fetched", False, str(exc))
             return {"ok": False, "steps": steps, "error": str(exc)}
 
         shots = list(_igdb_pick(game, "screenshots") or [])
         step("Screenshots listed", bool(shots), f"{len(shots)} found")
         sample = ""
         if shots:
-            h = await self._igdb_image_hash("Screenshot", shots[0], key)
-            sample = _igdb_img(h, IGDB_SIZE_THUMB) if h else ""
-            step("Image address resolved", bool(sample), sample or "no image id on the object")
+            sample = _igdb_img(_igdb_pick(shots[0], "image_id"), IGDB_SIZE_THUMB)
+            step("Image address resolved", bool(sample),
+                 sample or "no image_id on the expanded screenshot")
         return {"ok": True, "steps": steps, "igdb_id": igdb_id,
                 "name": label, "sample_image": sample}
 
@@ -1988,11 +2094,16 @@ class Plugin:
             # (Hasheous). OFF by default: when off, resolve_game does Steam
             # title-search only and non-Steam misses stay "unmatched".
             "nonSteamSources": False,
-            # Hasheous CLIENT API key. Empty = the keyless baseline (logo +
-            # description only). With a key, non-Steam games are enriched from
-            # IGDB (cover, screenshots, genres, developers). Stored locally in
-            # the plugin's settings file and sent ONLY to hasheous.org.
-            "hasheousApiKey": "",
+            # IGDB (via Twitch) application credentials. Both empty = the
+            # keyless baseline (logo + description only). With them, non-Steam
+            # games are enriched from IGDB (cover, screenshots, genres,
+            # developers). Free and self-serve: a Twitch account with 2FA and an
+            # application registered in the Twitch Developer Portal. Stored
+            # locally in this file; the secret is sent ONLY to id.twitch.tv to
+            # mint an access token, and is never logged or reported by
+            # test_igdb.
+            "igdbClientId": "",
+            "igdbClientSecret": "",
         }
         _sub = ("sections", "expanded")  # merged as sub-dicts, not replaced
         try:
@@ -2011,6 +2122,16 @@ class Plugin:
         return defaults
 
     async def set_settings(self, settings: dict):
+        try:
+            # A cached access token belongs to one client id/secret pair. If
+            # either changed, the cached token is either wrong or about to be,
+            # so drop it rather than let a stale token mask new credentials.
+            prev_id, prev_secret = _igdb_creds()
+            if (str(settings.get("igdbClientId", "") or "").strip() != prev_id
+                    or str(settings.get("igdbClientSecret", "") or "").strip() != prev_secret):
+                _igdb_forget_token()
+        except Exception:
+            pass
         try:
             os.makedirs(SETTINGS_DIR, exist_ok=True)
             tmp = SETTINGS_FILE + ".tmp"

--- a/main.py
+++ b/main.py
@@ -2083,27 +2083,37 @@ class Plugin:
             core, _, pre = str(v).lstrip("vV").partition("-")
             nums = tuple(int(x) for x in re.sub(r"[^0-9.]", "", core).split(".") if x)
             if not nums:
-                return ((0,), 1, "")
-            return (nums, 0 if pre else 1, pre)
+                return ((0,), 1, ())
+            # Natural order for the label: "beta.10" must beat "beta.9", which
+            # plain string comparison gets wrong.
+            label = tuple((0, int(p)) if p.isdigit() else (1, p) for p in pre.split(".") if p)
+            return (nums, 0 if pre else 1, label)
         except Exception:
-            return ((0,), 1, "")
+            return ((0,), 1, ())
 
     async def check_update(self, beta: bool = False):
         """Newest GitHub release vs the installed version (+ notes + download URL).
 
         Stable channel uses the `releases/latest` endpoint, which EXCLUDES
         pre-releases — so a `-beta` build is invisible to stable users. The beta
-        channel looks at all releases and takes the most-recently-published one
-        (which may be a pre-release), so opting in is the ONLY way to see betas.
+        channel looks at all releases (pre-releases included) and takes the
+        highest version, so opting in is the ONLY way to be offered a beta, and
+        a beta tester is still offered the stable release once it ships.
         """
         current = self._installed_version()
         try:
             loop = asyncio.get_running_loop()
             if beta:
+                # Beta channel: consider pre-releases too, and take the HIGHEST
+                # version rather than the most recently created — a stable
+                # release cut after a beta must still win over it.
                 rels = await loop.run_in_executor(
                     None, _http_get_json,
-                    "https://api.github.com/repos/Featherwolf/EnhancedGV/releases?per_page=10")
-                raw = rels[0] if isinstance(rels, list) and rels else {}
+                    "https://api.github.com/repos/Featherwolf/EnhancedGV/releases?per_page=20")
+                cands = [r for r in (rels if isinstance(rels, list) else [])
+                         if isinstance(r, dict) and not r.get("draft")]
+                raw = max(cands, key=lambda r: self._ver_tuple(str(r.get("tag_name", ""))),
+                          default={})
             else:
                 raw = await loop.run_in_executor(
                     None, _http_get_json,
@@ -2140,8 +2150,13 @@ class Plugin:
                 text = fh.read()
         except Exception as exc:
             return {"ok": False, "version": version, "error": str(exc)}
-        m = re.search(rf"^## v{re.escape(version)}\s*?\n(.*?)(?=^## |\Z)",
-                      text, re.S | re.M)
+        base = version.split("-", 1)[0]
+        m = (re.search(rf"^## v{re.escape(version)}\s*?\n(.*?)(?=^## |\Z)",
+                       text, re.S | re.M)
+             # A beta build is stamped "X.Y.Z-beta" but its notes live under
+             # "## vX.Y.Z" — a beta carries the version it becomes.
+             or re.search(rf"^## v{re.escape(base)}\s*?\n(.*?)(?=^## |\Z)",
+                          text, re.S | re.M))
         return {"ok": True, "version": version,
                 "notes": m.group(1).strip() if m else ""}
 

--- a/main.py
+++ b/main.py
@@ -224,6 +224,20 @@ def _read_cache_entry(kind: str, key: str):
     return None, False
 
 
+def _write_negative(kind: str, key: str, res) -> None:
+    """Negative-cache a failure — unless a GOOD blob is already on disk.
+
+    A stale-while-revalidate refresh runs in the background against a blob we
+    are still happily serving; if that refresh fails (offline, 429, SSL), the
+    old code replaced the good blob with the failure, and the content that was
+    on screen a moment ago was gone for good. Keep the positive blob instead: it
+    goes on aging normally and the next read simply retries the refresh."""
+    existing, _fresh = _read_cache_entry(kind, key)
+    if isinstance(existing, dict) and existing.get("ok") is not False:
+        return
+    _write_cache(kind, key, res, negative=True)
+
+
 def _write_cache(kind: str, key: str, data, negative: bool = False) -> None:
     try:
         os.makedirs(CACHE_DIR, exist_ok=True)
@@ -1181,17 +1195,17 @@ class Plugin:
                 if result.get("ok"):
                     _write_cache(kind, key, result)
                 else:
-                    _write_cache(kind, key, result, negative=True)
+                    _write_negative(kind, key, result)
                 return result
             except urllib.error.HTTPError as exc:
                 decky.logger.error(f"{kind} HTTP {exc.code} for {key}")
                 res = {"ok": False, "error": f"HTTP {exc.code}"}
-                _write_cache(kind, key, res, negative=True)
+                _write_negative(kind, key, res)
                 return res
             except Exception as exc:
                 decky.logger.error(f"{kind} fetch failed for {key}: {exc}")
                 res = {"ok": False, "error": str(exc)}
-                _write_cache(kind, key, res, negative=True)
+                _write_negative(kind, key, res)
                 return res
 
         task = asyncio.create_task(_do())

--- a/main.py
+++ b/main.py
@@ -180,11 +180,27 @@ def _build_ssl_context() -> ssl.SSLContext:
     try:
         return ssl.create_default_context()
     except Exception:
+        # Last resort so public, unauthenticated content still loads. Callers
+        # that send credentials must consult _ssl_verifies() and refuse.
         return ssl._create_unverified_context()
 
 
 _SSL_CTX = _build_ssl_context()
 _SSL_UNVERIFIED = ssl._create_unverified_context()
+
+
+def _ssl_verifies(ctx: ssl.SSLContext = None) -> bool:
+    """Whether a context actually validates certificates.
+
+    _build_ssl_context can degrade to an unverified context, and both variants
+    are the same CLASS — so `type(ctx).__name__` (what the startup log used to
+    print) cannot tell them apart. verify_mode/check_hostname can.
+    """
+    ctx = _SSL_CTX if ctx is None else ctx
+    try:
+        return bool(ctx.verify_mode != ssl.CERT_NONE and ctx.check_hostname)
+    except Exception:
+        return False
 
 
 def _http_get_json(url: str, headers: dict = None) -> dict:
@@ -357,6 +373,11 @@ def _igdb_token_sync(client_id: str, client_secret: str) -> str:
     except Exception:
         pass
 
+    if not _ssl_verifies():
+        raise RuntimeError(
+            "refusing to send IGDB credentials: TLS certificate verification is "
+            "unavailable on this device (no usable CA bundle)")
+
     body = urllib.parse.urlencode({
         "client_id": client_id,
         "client_secret": client_secret,
@@ -395,6 +416,11 @@ def _igdb_forget_token() -> None:
 def _igdb_post_sync(endpoint: str, body: str, client_id: str, token: str):
     """One POST against IGDB v4. Returns the decoded list (IGDB always answers
     with an array). Apicalypse bodies are plain text, not JSON."""
+    if not _ssl_verifies():
+        raise RuntimeError(
+            "refusing to send IGDB credentials: TLS certificate verification is "
+            "unavailable on this device (no usable CA bundle)")
+
     req = urllib.request.Request(
         f"{IGDB_API}/{endpoint}", data=body.encode("utf-8"), method="POST",
         headers={"User-Agent": USER_AGENT, "Accept": "application/json",
@@ -1231,8 +1257,8 @@ class Plugin:
         self._inflight = {}
         os.makedirs(CACHE_DIR, exist_ok=True)
         self._purge_stale_cache()
-        decky.logger.info("EnhancedGV backend started (SSL ctx: %s)",
-                          type(_SSL_CTX).__name__)
+        decky.logger.info("EnhancedGV backend started (TLS verification: %s)",
+                          "on" if _ssl_verifies() else "OFF - no usable CA bundle")
 
     def _purge_stale_cache(self):
         """Drop the on-disk cache when CACHE_VERSION changes, so a fix ships with
@@ -2214,7 +2240,15 @@ class Plugin:
             try:
                 try:
                     resp = urllib.request.urlopen(req, timeout=12, context=_SSL_CTX)
-                except urllib.error.URLError:
+                except urllib.error.URLError as exc:
+                    # Only a CERTIFICATE failure justifies dropping verification,
+                    # and only here because this probe reads public CDN bytes and
+                    # carries no credentials. A refused connection or DNS failure
+                    # must surface as itself, not be retried unverified.
+                    reason = getattr(exc, "reason", exc)
+                    if not (isinstance(reason, ssl.SSLError)
+                            or "CERTIFICATE_VERIFY_FAILED" in str(exc)):
+                        raise
                     resp = urllib.request.urlopen(req, timeout=12, context=_SSL_UNVERIFIED)
                 with resp:
                     data = resp.read(65536)

--- a/main.py
+++ b/main.py
@@ -2068,10 +2068,25 @@ class Plugin:
 
     @staticmethod
     def _ver_tuple(v: str):
+        """Order versions with prereleases BELOW the release they precede.
+
+        The old form stripped every non-digit, so "0.19.0-beta" collapsed to
+        (0,19,0) — identical to the finished 0.19.0, meaning a beta tester was
+        told "up to date" forever and never offered the real release. Worse,
+        "0.17.0-beta.1" became (0,17,0,1), which sorts ABOVE (0,17,0) and offered
+        a prerelease as an upgrade over the finished version.
+
+        Now: compare the numeric core first, then rank release (1) above
+        prerelease (0), tie-broken by the prerelease label so beta.2 > beta.1.
+        """
         try:
-            return tuple(int(x) for x in re.sub(r"[^0-9.]", "", v).split(".") if x)
+            core, _, pre = str(v).lstrip("vV").partition("-")
+            nums = tuple(int(x) for x in re.sub(r"[^0-9.]", "", core).split(".") if x)
+            if not nums:
+                return ((0,), 1, "")
+            return (nums, 0 if pre else 1, pre)
         except Exception:
-            return (0,)
+            return ((0,), 1, "")
 
     async def check_update(self, beta: bool = False):
         """Newest GitHub release vs the installed version (+ notes + download URL).

--- a/main.py
+++ b/main.py
@@ -1811,6 +1811,52 @@ class Plugin:
         out["igdb_enriched"] = True
         return out
 
+    async def get_all_provider(self, provider, id, lang: str = "english",
+                               cc: str = "us"):
+        """Non-Steam metadata aggregate — same AppData shape as get_all, with
+        reviews/news/deck = {ok:False} (they hide cleanly in the panel).
+
+        This is the callable the frontend reaches for every non-Steam game
+        (src/api.ts -> "get_all_provider"), so without it the whole Hasheous
+        path answers "unknown method" and no non-Steam panel can render.
+        """
+        if provider != "hasheous":
+            return {"ok": False, "error": f"unknown provider: {provider}"}
+        try:
+            gid = int(id)
+        except Exception:
+            return {"ok": False, "error": "invalid provider id"}
+        url = f"{HASHEOUS_BASE}/DataObjects/Game/{gid}"
+
+        def norm(raw):
+            if not isinstance(raw, dict) or not raw.get("name"):
+                return {"ok": False, "error": "no hasheous data"}
+            return _normalize_hasheous(raw)
+
+        appdetails = await self._fetch("hasheous", str(gid), url, norm)
+
+        # IGDB artwork rides on top of the keyless baseline. Deliberately AFTER
+        # _fetch, never inside norm(): _fetch caches its callback's output, and
+        # a merged result cached against one baseline would later be served over
+        # a different one. _igdb_delta caches only the IGDB half, so a cached
+        # baseline still gets enriched here.
+        if isinstance(appdetails, dict) and appdetails.get("ok") is not False:
+            try:
+                igdb_id = int(appdetails.get("igdb_id") or 0)
+            except Exception:
+                igdb_id = 0
+            if igdb_id:
+                appdetails = await self._igdb_enrich(igdb_id, appdetails)
+
+        return {
+            "ok": True,
+            "appid": gid,
+            "appdetails": appdetails,
+            "reviews": {"ok": False, "error": "reviews are Steam-only"},
+            "news": {"ok": False, "error": "update history is Steam-only"},
+            "deck": {"ok": False, "error": "not a Steam app"},
+        }
+
     async def test_igdb(self, game_appid=0):
         """Per-step IGDB probe for the QAM, so a tester can see exactly where
         enrichment stops instead of just 'no artwork appeared'. Never returns the

--- a/main.py
+++ b/main.py
@@ -186,7 +186,33 @@ def _build_ssl_context() -> ssl.SSLContext:
 
 
 _SSL_CTX = _build_ssl_context()
+# Kept ONLY for the trailer byte-probe diagnostic, which reads public CDN bytes
+# and carries nothing. Every content path verifies: an attacker who can make the
+# certificate check fail is exactly the attacker who then gets to choose the
+# HTML the sanitizer sees, the URLs the panel opens and the release JSON the
+# updater trusts. An automatic downgrade handed all of that away for free.
 _SSL_UNVERIFIED = ssl._create_unverified_context()
+
+# Ceiling on any JSON body we will buffer. The store and provider payloads are
+# tens of KB; anything near this is a hostile or broken upstream.
+MAX_RESPONSE_BYTES = 8 * 1024 * 1024
+
+
+class _NoRedirect(urllib.request.HTTPRedirectHandler):
+    """Refuse to follow redirects on credential-bearing requests.
+
+    urllib's default opener rebuilds a redirected request keeping every header
+    except Content-Length/Content-Type — so Authorization and Client-ID follow
+    the Location to ANY host, http:// included. A compromised api.igdb.com could
+    therefore turn one 302 into credential exfiltration in the clear.
+    """
+
+    def redirect_request(self, req, fp, code, msg, headers, newurl):
+        return None
+
+
+_IGDB_OPENER = urllib.request.build_opener(
+    _NoRedirect, urllib.request.HTTPSHandler(context=_SSL_CTX))
 
 
 def _ssl_verifies(ctx: ssl.SSLContext = None) -> bool:
@@ -208,20 +234,10 @@ def _http_get_json(url: str, headers: dict = None) -> dict:
     if headers:
         hdrs.update(headers)
     req = urllib.request.Request(url, headers=hdrs)
-    try:
-        with urllib.request.urlopen(req, timeout=REQUEST_TIMEOUT, context=_SSL_CTX) as resp:
-            raw = resp.read().decode("utf-8", "replace")
-    except urllib.error.URLError as exc:
-        # Retry without verification if the failure is a certificate problem.
-        reason = getattr(exc, "reason", exc)
-        if isinstance(reason, ssl.SSLError) or "CERTIFICATE_VERIFY_FAILED" in str(exc):
-            decky.logger.warning("SSL verify failed; retrying unverified (public data)")
-            with urllib.request.urlopen(
-                req, timeout=REQUEST_TIMEOUT, context=_SSL_UNVERIFIED
-            ) as resp:
-                raw = resp.read().decode("utf-8", "replace")
-        else:
-            raise
+    with urllib.request.urlopen(req, timeout=REQUEST_TIMEOUT, context=_SSL_CTX) as resp:
+        raw = resp.read(MAX_RESPONSE_BYTES + 1).decode("utf-8", "replace")
+    if len(raw.encode("utf-8", "ignore")) > MAX_RESPONSE_BYTES:
+        raise ValueError("response exceeds the size limit")
     return json.loads(raw)
 
 
@@ -232,18 +248,10 @@ def _http_post_json(url: str, payload: dict) -> dict:
         headers={"User-Agent": USER_AGENT, "Content-Type": "application/json",
                  "Accept": "application/json"},
     )
-    try:
-        with urllib.request.urlopen(req, timeout=REQUEST_TIMEOUT, context=_SSL_CTX) as resp:
-            raw = resp.read().decode("utf-8", "replace")
-    except urllib.error.URLError as exc:
-        reason = getattr(exc, "reason", exc)
-        if isinstance(reason, ssl.SSLError) or "CERTIFICATE_VERIFY_FAILED" in str(exc):
-            with urllib.request.urlopen(
-                req, timeout=REQUEST_TIMEOUT, context=_SSL_UNVERIFIED
-            ) as resp:
-                raw = resp.read().decode("utf-8", "replace")
-        else:
-            raise
+    with urllib.request.urlopen(req, timeout=REQUEST_TIMEOUT, context=_SSL_CTX) as resp:
+        raw = resp.read(MAX_RESPONSE_BYTES + 1).decode("utf-8", "replace")
+    if len(raw.encode("utf-8", "ignore")) > MAX_RESPONSE_BYTES:
+        raise ValueError("response exceeds the size limit")
     return json.loads(raw)
 
 
@@ -337,6 +345,9 @@ def _feature_non_steam() -> bool:
         return False
 
 
+SECRET_KEY = "igdbClientSecret"   # never returned by get_settings
+
+
 def _igdb_creds():
     """(client_id, client_secret) for IGDB, or ("", "") when not configured.
 
@@ -388,8 +399,8 @@ def _igdb_token_sync(client_id: str, client_secret: str) -> str:
         headers={"User-Agent": USER_AGENT,
                  "Content-Type": "application/x-www-form-urlencoded",
                  "Accept": "application/json"})
-    with urllib.request.urlopen(req, timeout=REQUEST_TIMEOUT, context=_SSL_CTX) as resp:
-        got = json.loads(resp.read().decode("utf-8", "replace"))
+    with _IGDB_OPENER.open(req, timeout=REQUEST_TIMEOUT) as resp:
+        got = json.loads(resp.read(MAX_RESPONSE_BYTES + 1).decode("utf-8", "replace"))
 
     token = str(got.get("access_token") or "")
     if not token:
@@ -426,8 +437,11 @@ def _igdb_post_sync(endpoint: str, body: str, client_id: str, token: str):
         headers={"User-Agent": USER_AGENT, "Accept": "application/json",
                  "Content-Type": "text/plain",
                  "Client-ID": client_id, "Authorization": f"Bearer {token}"})
-    with urllib.request.urlopen(req, timeout=REQUEST_TIMEOUT, context=_SSL_CTX) as resp:
-        return json.loads(resp.read().decode("utf-8", "replace"))
+    with _IGDB_OPENER.open(req, timeout=REQUEST_TIMEOUT) as resp:
+        raw = resp.read(MAX_RESPONSE_BYTES + 1).decode("utf-8", "replace")
+    if len(raw.encode("utf-8", "ignore")) > MAX_RESPONSE_BYTES:
+        raise ValueError("IGDB response exceeds the size limit")
+    return json.loads(raw)
 
 
 def _igdb_img(image_hash: str, size: str) -> str:
@@ -522,6 +536,29 @@ def _parse_appid(s):
 # --------------------------------------------------------------------------- #
 # Text helpers: HTML sanitize + BBCODE -> HTML
 # --------------------------------------------------------------------------- #
+_GITHUB_HOSTS = frozenset((
+    "github.com", "api.github.com", "objects.githubusercontent.com",
+    "release-assets.githubusercontent.com", "codeload.github.com",
+))
+
+
+def _github_url(u) -> str:
+    """A URL from the release API, or "" if it is not plainly GitHub over https.
+
+    check_update's result is handed to Navigation.NavigateToExternalWeb and shown
+    as the place to download a new build, so whoever controls that JSON chooses
+    where the user is sent. Pin it to https and to GitHub's own hosts rather than
+    trusting the field.
+    """
+    try:
+        parts = urllib.parse.urlsplit(str(u or "").strip())
+    except Exception:
+        return ""
+    if parts.scheme != "https" or parts.hostname is None:
+        return ""
+    return u if parts.hostname.lower() in _GITHUB_HOSTS else ""
+
+
 def _safe_url(u) -> str:
     """Only allow http(s) (and protocol-relative / relative / anchor) URLs in
     HTML rendered via dangerouslySetInnerHTML; neutralize javascript:/data:/
@@ -2191,7 +2228,44 @@ class Plugin:
                         defaults[key].update(saved[key])
         except Exception:
             pass
+        # The client SECRET never leaves the backend. This method is a
+        # string-named RPC with no caller check, so ANY code in the Steam UI —
+        # including another Decky plugin — can invoke it; returning the secret
+        # made it readable by all of them. The UI only ever needs to know
+        # whether one is stored, and it never prefills the field.
+        defaults.pop(SECRET_KEY, None)
+        defaults["igdbClientSecretSet"] = bool(_igdb_creds()[1])
         return defaults
+
+    async def clear_igdb_credentials(self):
+        """Erase the stored IGDB credentials and any token minted from them.
+
+        set_settings deliberately treats an absent or empty secret as "leave it
+        alone", because get_settings redacts it and the frontend writes back what
+        it was given — without that rule, every unrelated settings save would
+        wipe the secret. Removal therefore needs its own explicit call.
+        """
+        try:
+            try:
+                with open(SETTINGS_FILE, "r", encoding="utf-8") as fh:
+                    saved = json.load(fh)
+            except Exception:
+                saved = {}
+            if not isinstance(saved, dict):
+                saved = {}
+            saved["igdbClientId"] = ""
+            saved[SECRET_KEY] = ""
+            os.makedirs(SETTINGS_DIR, exist_ok=True)
+            tmp = SETTINGS_FILE + ".tmp"
+            fd = os.open(tmp, os.O_WRONLY | os.O_CREAT | os.O_TRUNC, 0o600)
+            with os.fdopen(fd, "w", encoding="utf-8") as fh:
+                json.dump(saved, fh, indent=2)
+            os.replace(tmp, SETTINGS_FILE)
+            _igdb_forget_token()
+            return {"ok": True}
+        except Exception as exc:
+            decky.logger.error(f"clear_igdb_credentials failed: {exc}")
+            return {"ok": False, "error": str(exc)}
 
     async def set_settings(self, settings: dict):
         try:
@@ -2199,16 +2273,36 @@ class Plugin:
             # either changed, the cached token is either wrong or about to be,
             # so drop it rather than let a stale token mask new credentials.
             prev_id, prev_secret = _igdb_creds()
+            new_secret = str(settings.get(SECRET_KEY, "") or "").strip()
             if (str(settings.get("igdbClientId", "") or "").strip() != prev_id
-                    or str(settings.get("igdbClientSecret", "") or "").strip() != prev_secret):
+                    or (new_secret and new_secret != prev_secret)):
                 _igdb_forget_token()
         except Exception:
             pass
         try:
             os.makedirs(SETTINGS_DIR, exist_ok=True)
+            try:
+                os.chmod(SETTINGS_DIR, 0o700)
+            except Exception:
+                pass
+            # get_settings redacts the secret, and the frontend writes back what
+            # it was given — so an incoming payload with no secret means "leave
+            # it alone", not "erase it". Only an explicit non-empty value sets a
+            # new one, and only clear_igdb_credentials removes it.
+            merged = dict(settings)
+            if not str(merged.get(SECRET_KEY, "") or "").strip():
+                kept = _igdb_creds()[1]
+                if kept:
+                    merged[SECRET_KEY] = kept
+            merged.pop("igdbClientSecretSet", None)  # a report, not a setting
             tmp = SETTINGS_FILE + ".tmp"
-            with open(tmp, "w", encoding="utf-8") as fh:
-                json.dump(settings, fh, indent=2)
+            # 0600 from the moment of creation. open(tmp, "w") would have used
+            # 0666 & ~umask = 0644, and os.replace carries that mode onto the
+            # real file — which is how a Twitch client secret ended up
+            # world-readable next to a 0600 token file.
+            fd = os.open(tmp, os.O_WRONLY | os.O_CREAT | os.O_TRUNC, 0o600)
+            with os.fdopen(fd, "w", encoding="utf-8") as fh:
+                json.dump(merged, fh, indent=2)
             os.replace(tmp, SETTINGS_FILE)
             return {"ok": True}
         except Exception as exc:
@@ -2233,6 +2327,11 @@ class Plugin:
             return {"ok": False, "error": "no source candidates"}
 
         def probe(url: str) -> dict:
+            # Candidates come from appdetails, i.e. from the network. Without a
+            # scheme check this diagnostic reads file:// and probes the LAN on
+            # behalf of whoever controls that response.
+            if urllib.parse.urlsplit(url).scheme != "https":
+                return {"url": str(url)[:60], "status": 0, "error": "non-https source"}
             req = urllib.request.Request(
                 url, headers={"User-Agent": USER_AGENT, "Range": "bytes=0-65535"}
             )
@@ -2337,7 +2436,7 @@ class Plugin:
             zip_url = ""
             for a in raw.get("assets") or []:
                 if a.get("name") == "EnhancedGV.zip":
-                    zip_url = a.get("browser_download_url", "")
+                    zip_url = _github_url(a.get("browser_download_url", ""))
                     break
             return {
                 "ok": True,
@@ -2347,7 +2446,7 @@ class Plugin:
                 "has_update": bool(latest) and self._ver_tuple(latest) > self._ver_tuple(current),
                 "prerelease": bool(raw.get("prerelease")),
                 "channel": "beta" if beta else "stable",
-                "url": raw.get("html_url", ""),
+                "url": _github_url(raw.get("html_url", "")),
                 "zip_url": zip_url,
             }
         except Exception as exc:

--- a/main.py
+++ b/main.py
@@ -17,6 +17,7 @@ import json
 import time
 import html
 import asyncio
+import functools
 import urllib.parse
 import urllib.request
 import urllib.error
@@ -41,7 +42,7 @@ CACHE_VERSION = "0.15.0-lang"
 TTL = {"appdetails": 86400, "deck": 86400, "reviews": 3600, "reviews_sum": 3600,
        "reviews_recent": 3600, "news": 3600,
        # Non-Steam / emulated metadata is essentially static — cache it a week.
-       "hasheous": 604800}
+       "hasheous": 604800, "igdb": 604800}
 # Negative results (fetch failed / success=false) are cached only briefly so a
 # transient network/SSL failure doesn't linger after it's resolved.
 NEGATIVE_TTL = 120
@@ -93,6 +94,27 @@ CLAN_IMAGE_BASE = "https://clan.akamai.steamstatic.com/images"
 #   -> DataObjects/Game/{id} (name, AIDescription, Logo, Tags, publisher, IGDB id)
 # The rich IGDB proxy (cover/screenshots/genres) is key-gated (a later, opt-in
 # phase); this baseline is entirely keyless and works with the feature toggled on.
+# --- IGDB enrichment (opt-in, needs a Hasheous CLIENT API key) --------------- #
+# Hasheous proxies IGDB at /MetadataProxy/IGDB/*. Verified against the live
+# OpenAPI spec and by probing the running service:
+#   * METADATA is key-gated: /MetadataProxy/IGDB/Game?Id=… answers 401 without an
+#     `X-Client-API-Key` header (securityScheme "Client API Key").
+#   * IMAGES are NOT key-gated: /MetadataProxy/IGDB/Image/{hash}.jpg answers 200
+#     with no key — but it serves the ORIGINAL (a cover measured at 2.7 MB), and
+#     it takes no size parameter (a t_cover_big-style path 404s).
+# So metadata goes through the proxy with the key, and image URLs point at IGDB's
+# own public CDN, which does serve sized renditions keylessly. Measured on the
+# same cover: t_thumb 3 KB / t_cover_big 21 KB / t_screenshot_med 40 KB /
+# t_1080p 163 KB, versus 2.7 MB from the proxy. On a Deck over wifi, with a
+# thumbnail strip of a dozen shots, that difference is the whole feature.
+IGDB_IMG_CDN = "https://images.igdb.com/igdb/image/upload"
+IGDB_SIZE_COVER = "t_cover_big"
+IGDB_SIZE_THUMB = "t_screenshot_med"
+IGDB_SIZE_FULL = "t_1080p"
+# Screenshot/artwork metadata is one request PER image id, so cap how many we
+# resolve: enough to fill the carousel, few enough to stay polite and quick.
+IGDB_MAX_SHOTS = 12
+
 HASHEOUS_BASE = "https://hasheous.org/api/v1"
 HASHEOUS_IMAGE = HASHEOUS_BASE + "/Images/"  # + {image_hash}
 # sha1("") — Hasheous stores this as a placeholder/empty Logo; never use it.
@@ -131,8 +153,11 @@ _SSL_CTX = _build_ssl_context()
 _SSL_UNVERIFIED = ssl._create_unverified_context()
 
 
-def _http_get_json(url: str) -> dict:
-    req = urllib.request.Request(url, headers={"User-Agent": USER_AGENT})
+def _http_get_json(url: str, headers: dict = None) -> dict:
+    hdrs = {"User-Agent": USER_AGENT}
+    if headers:
+        hdrs.update(headers)
+    req = urllib.request.Request(url, headers=hdrs)
     try:
         with urllib.request.urlopen(req, timeout=REQUEST_TIMEOUT, context=_SSL_CTX) as resp:
             raw = resp.read().decode("utf-8", "replace")
@@ -246,6 +271,42 @@ def _feature_non_steam() -> bool:
             return bool(json.load(fh).get("nonSteamSources", False))
     except Exception:
         return False
+
+
+def _igdb_key() -> str:
+    """The Hasheous CLIENT API key, or "" when enrichment is off. Read from the
+    settings file for the same reason as _feature_non_steam. NEVER logged."""
+    try:
+        with open(SETTINGS_FILE, "r", encoding="utf-8") as fh:
+            return str(json.load(fh).get("hasheousApiKey", "") or "").strip()
+    except Exception:
+        return ""
+
+
+def _igdb_img(image_hash: str, size: str) -> str:
+    """A sized IGDB CDN URL. Keyless and public (see the note above)."""
+    h = re.sub(r"[^A-Za-z0-9_-]", "", str(image_hash or ""))
+    return f"{IGDB_IMG_CDN}/{size}/{h}.jpg" if h else ""
+
+
+def _igdb_pick(obj, *names):
+    """Read the first present key from an IGDB proxy object.
+
+    The proxy is a C# service in front of IGDB's snake_case JSON, and the OpenAPI
+    spec types most nested objects as bare `object` — so the exact casing of a
+    field is not guaranteed by the contract. Rather than pin one spelling and
+    break on the other, try the plausible ones. Unverified against a live keyed
+    response (no key available here), so this stays deliberately forgiving.
+    """
+    if not isinstance(obj, dict):
+        return None
+    for n in names:
+        for cand in (n, n[:1].upper() + n[1:], n[:1].lower() + n[1:],
+                     n.replace("_", ""), n.replace("_", "").lower(),
+                     "".join(w[:1].upper() + w[1:] for w in n.split("_"))):
+            if cand in obj and obj[cand] not in (None, ""):
+                return obj[cand]
+    return None
 
 
 def _rec_to_result(rec: dict) -> dict:
@@ -978,10 +1039,20 @@ def _normalize_hasheous(obj: dict) -> dict:
             platform_name = sd[0].get("Platform") or ""
 
     website = None
+    igdb_id = 0
     for m in (obj.get("metadata") or []):
-        if m.get("source") == "IGDB" and m.get("status") == "Mapped" and m.get("link"):
-            website = m["link"]
-            break
+        if m.get("source") == "IGDB" and m.get("status") == "Mapped":
+            if m.get("link") and not website:
+                website = m["link"]
+            # `id` (== immutableId) is the IGDB game id — the handle the keyed
+            # MetadataProxy needs. Verified on a live DataObject: Super Metroid
+            # (Hasheous 6292) carries IGDB id 1103.
+            try:
+                igdb_id = int(m.get("id") or m.get("immutableId") or 0)
+            except Exception:
+                igdb_id = 0
+            if website and igdb_id:
+                break
 
     year = ""
     for sd in (obj.get("signatureDataObjects") or []):
@@ -1025,6 +1096,8 @@ def _normalize_hasheous(obj: dict) -> dict:
         "supported_languages_html": langs,
         "pc_requirements": None,
         "content_descriptor_notes": None,
+        # Handle for the opt-in IGDB enrichment pass (0 = unmapped).
+        "igdb_id": igdb_id,
     }
 
 
@@ -1477,32 +1550,231 @@ class Plugin:
                                 "platform": (g.get("platform") or {}).get("name", "")}
         return {"ok": False, "error": "no resolvable rom hash"}
 
-    async def get_all_provider(self, provider, id, lang: str = "english",
-                               cc: str = "us"):
-        """Non-Steam metadata aggregate — same AppData shape as get_all, with
-        reviews/news/deck = {ok:False} (they hide cleanly in the panel)."""
-        if provider != "hasheous":
-            return {"ok": False, "error": f"unknown provider: {provider}"}
+    # --- IGDB enrichment (opt-in; needs a Hasheous client API key) --------- #
+    async def _igdb_get(self, path: str, params: dict, key: str):
+        """One keyed GET against the IGDB metadata proxy."""
+        url = f"{HASHEOUS_BASE}/MetadataProxy/IGDB/{path}?" + urllib.parse.urlencode(params)
+        loop = asyncio.get_running_loop()
+        return await loop.run_in_executor(
+            None, functools.partial(_http_get_json, url, {"X-Client-API-Key": key})
+        )
+
+    async def _igdb_image_hash(self, kind: str, image_id, key: str):
+        """Resolve one Cover/Screenshot/Artwork id to its IGDB image hash."""
         try:
-            gid = int(id)
+            obj = await self._igdb_get(kind, {"Id": int(image_id)}, key)
         except Exception:
-            return {"ok": False, "error": "invalid provider id"}
-        url = f"{HASHEOUS_BASE}/DataObjects/Game/{gid}"
+            return None
+        return _igdb_pick(obj, "image_id", "imageId", "hash")
 
-        def norm(raw):
-            if not isinstance(raw, dict) or not raw.get("name"):
-                return {"ok": False, "error": "no hasheous data"}
-            return _normalize_hasheous(raw)
+    async def _igdb_names(self, kind: str, ids, key: str, limit: int = 12):
+        """Resolve a list of ids (Genre, Company, …) to their display names."""
+        out = []
+        for chunk in [list(ids)[:limit]]:
+            got = await asyncio.gather(
+                *[self._igdb_get(kind, {"Id": int(i)}, key) for i in chunk],
+                return_exceptions=True,
+            )
+            for o in got:
+                if isinstance(o, BaseException):
+                    continue
+                n = _igdb_pick(o, "name")
+                if n:
+                    out.append(str(n))
+        return out
 
-        appdetails = await self._fetch("hasheous", str(gid), url, norm)
-        return {
-            "ok": True,
-            "appid": gid,
-            "appdetails": appdetails,
-            "reviews": {"ok": False, "error": "reviews are Steam-only"},
-            "news": {"ok": False, "error": "update history is Steam-only"},
-            "deck": {"ok": False, "error": "not a Steam app"},
-        }
+    async def _igdb_delta(self, igdb_id: int, key: str) -> dict:
+        """Fetch the IGDB-derived fields for a game. CACHED ON ITS OWN — never
+        cache the merged result: the merge depends on what the Hasheous baseline
+        already had, so a cached merge made against one baseline would be served
+        over a different one. Returns {} on any failure."""
+        cached = _read_cache_entry("igdb", str(igdb_id))[0]
+        if isinstance(cached, dict):
+            return cached
+
+        try:
+            game = await self._igdb_get("Game", {"Id": int(igdb_id)}, key)
+        except urllib.error.HTTPError as exc:
+            # 401/403 = missing/rejected key. Logged without the key itself.
+            decky.logger.error(f"igdb: HTTP {exc.code} for game {igdb_id}")
+            return {}
+        except Exception as exc:
+            decky.logger.error(f"igdb: game {igdb_id} failed: {exc}")
+            return {}
+        if not isinstance(game, dict):
+            return {}
+
+        delta = {}
+
+        cover_id = _igdb_pick(game, "cover")
+        if cover_id:
+            h = await self._igdb_image_hash("Cover", cover_id, key)
+            if h:
+                delta["header_image"] = _igdb_img(h, IGDB_SIZE_COVER)
+
+        # Screenshots (+ artworks as filler) — the media hero is the whole point
+        # of this phase; the keyless baseline has none.
+        pairs = ([("Screenshot", i) for i in (_igdb_pick(game, "screenshots") or [])] +
+                 [("Artwork", i) for i in (_igdb_pick(game, "artworks") or [])])[:IGDB_MAX_SHOTS]
+        shots = []
+        if pairs:
+            hashes = await asyncio.gather(
+                *[self._igdb_image_hash(k, i, key) for k, i in pairs],
+                return_exceptions=True,
+            )
+            for (_kind, ident), h in zip(pairs, hashes):
+                if isinstance(h, BaseException) or not h:
+                    continue
+                shots.append({"id": int(ident),
+                              "thumb": _igdb_img(h, IGDB_SIZE_THUMB),
+                              "full": _igdb_img(h, IGDB_SIZE_FULL)})
+        if shots:
+            delta["screenshots"] = shots
+
+        gids = list(_igdb_pick(game, "genres") or [])
+        if gids:
+            names = await self._igdb_names("Genre", gids, key)
+            if names:
+                delta["genres"] = [{"id": n, "description": n} for n in names]
+
+        ic_ids = list(_igdb_pick(game, "involved_companies") or [])
+        if ic_ids:
+            devs, pubs = [], []
+            got = await asyncio.gather(
+                *[self._igdb_get("InvolvedCompany", {"Id": int(i)}, key)
+                  for i in ic_ids[:8]],
+                return_exceptions=True,
+            )
+            for ic in got:
+                if isinstance(ic, BaseException) or not isinstance(ic, dict):
+                    continue
+                cid = _igdb_pick(ic, "company")
+                if not cid:
+                    continue
+                try:
+                    comp = await self._igdb_get("Company", {"Id": int(cid)}, key)
+                except Exception:
+                    continue
+                nm = _igdb_pick(comp, "name")
+                if not nm:
+                    continue
+                if _igdb_pick(ic, "developer"):
+                    devs.append(str(nm))
+                elif _igdb_pick(ic, "publisher"):
+                    pubs.append(str(nm))
+            if devs:
+                delta["developers"] = devs
+            if pubs:
+                delta["publishers"] = pubs
+
+        summary = _igdb_pick(game, "summary")
+        if summary:
+            delta["summary_html"] = _sanitize_html(
+                "<p>" + html.escape(str(summary), quote=False).replace("\n", "<br>") + "</p>")
+            delta["summary_text"] = re.sub(r"\s+", " ", str(summary)).strip()[:320]
+
+        url_ = _igdb_pick(game, "url")
+        if url_:
+            delta["website"] = _safe_url(url_)
+
+        if delta:
+            _write_cache("igdb", str(igdb_id), delta)
+        return delta
+
+    async def _igdb_enrich(self, igdb_id: int, base: dict) -> dict:
+        """Layer IGDB artwork/details onto a normalized Hasheous AppDetails.
+
+        Best-effort throughout: a bad key, a rate limit or an unexpected shape
+        degrades to the keyless baseline rather than blanking the panel. Hasheous
+        data WINS wherever it has some — IGDB only fills what was empty. The one
+        exception is `screenshots`, which the baseline can never populate.
+        """
+        key = _igdb_key()
+        if not key or not igdb_id:
+            return base
+        delta = await self._igdb_delta(int(igdb_id), key)
+        if not delta:
+            return base
+
+        out = dict(base)
+        if delta.get("screenshots"):
+            out["screenshots"] = delta["screenshots"]
+        for field in ("header_image", "website", "developers", "publishers"):
+            if delta.get(field) and not out.get(field):
+                out[field] = delta[field]
+        # Genres: the baseline's are Hasheous tag soup, so prefer IGDB's when it
+        # has any — this is a quality upgrade, not a gap-fill.
+        if delta.get("genres"):
+            out["genres"] = delta["genres"]
+        if delta.get("summary_html") and not (base.get("about_html") or "").strip():
+            out["about_html"] = delta["summary_html"]
+            if not (base.get("short_description") or "").strip():
+                out["short_description"] = delta.get("summary_text", "")
+        out["igdb_enriched"] = True
+        return out
+
+    async def test_igdb(self, game_appid=0):
+        """Per-step IGDB probe for the QAM, so a beta tester can see exactly
+        where enrichment stops instead of just 'no artwork appeared'. Never
+        returns the key itself — only whether one is set and how long it is."""
+        key = _igdb_key()
+        steps = []
+
+        def step(name, ok, detail=""):
+            steps.append({"name": name, "ok": bool(ok), "detail": str(detail)[:200]})
+
+        step("Non-Steam sources enabled", _feature_non_steam(),
+             "on" if _feature_non_steam() else "turn it on above")
+        step("API key present", bool(key), f"{len(key)} chars" if key else "no key saved")
+        if not key:
+            return {"ok": False, "steps": steps, "error": "no API key"}
+
+        # Which game? The one on screen if it resolves to Hasheous, else a known
+        # public mapping (Super Metroid) so the key itself can still be tested.
+        igdb_id, label = 0, ""
+        try:
+            rec = _read_matches().get(str(int(game_appid or 0)))
+        except Exception:
+            rec = None
+        if isinstance(rec, dict) and rec.get("provider") == "hasheous":
+            try:
+                raw = await self._fetch(
+                    "hasheous", str(rec["provider_id"]),
+                    f"{HASHEOUS_BASE}/DataObjects/Game/{int(rec['provider_id'])}",
+                    lambda r: _normalize_hasheous(r) if isinstance(r, dict) and r.get("name")
+                    else {"ok": False, "error": "no hasheous data"})
+                igdb_id = int((raw or {}).get("igdb_id") or 0)
+                label = (raw or {}).get("name") or ""
+            except Exception as exc:
+                step("Look up this game on Hasheous", False, str(exc))
+        if igdb_id:
+            step("This game maps to IGDB", True, f"{label} -> IGDB {igdb_id}")
+        else:
+            igdb_id, label = 1103, "Super Metroid (fallback probe)"
+            step("This game maps to IGDB", False,
+                 "no IGDB mapping for this game; testing the key against a known title")
+
+        try:
+            game = await self._igdb_get("Game", {"Id": igdb_id}, key)
+            step("IGDB metadata (key accepted)", isinstance(game, dict),
+                 _igdb_pick(game, "name") or "no name field")
+        except urllib.error.HTTPError as exc:
+            step("IGDB metadata (key accepted)", False,
+                 f"HTTP {exc.code}" + (" — key rejected" if exc.code in (401, 403) else ""))
+            return {"ok": False, "steps": steps, "error": f"HTTP {exc.code}"}
+        except Exception as exc:
+            step("IGDB metadata (key accepted)", False, str(exc))
+            return {"ok": False, "steps": steps, "error": str(exc)}
+
+        shots = list(_igdb_pick(game, "screenshots") or [])
+        step("Screenshots listed", bool(shots), f"{len(shots)} found")
+        sample = ""
+        if shots:
+            h = await self._igdb_image_hash("Screenshot", shots[0], key)
+            sample = _igdb_img(h, IGDB_SIZE_THUMB) if h else ""
+            step("Image address resolved", bool(sample), sample or "no image id on the object")
+        return {"ok": True, "steps": steps, "igdb_id": igdb_id,
+                "name": label, "sample_image": sample}
 
     async def resolve_game(self, game_appid, is_shortcut: bool = False,
                            title: str = "", lang: str = "english", cc: str = "us",
@@ -1702,6 +1974,11 @@ class Plugin:
             # (Hasheous). OFF by default: when off, resolve_game does Steam
             # title-search only and non-Steam misses stay "unmatched".
             "nonSteamSources": False,
+            # Hasheous CLIENT API key. Empty = the keyless baseline (logo +
+            # description only). With a key, non-Steam games are enriched from
+            # IGDB (cover, screenshots, genres, developers). Stored locally in
+            # the plugin's settings file and sent ONLY to hasheous.org.
+            "hasheousApiKey": "",
         }
         _sub = ("sections", "expanded")  # merged as sub-dicts, not replaced
         try:

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "enhancedgv",
-  "version": "0.1.0",
+  "version": "0.19.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "enhancedgv",
-      "version": "0.1.0",
+      "version": "0.19.0",
       "license": "BSD-3-Clause",
       "dependencies": {
         "@decky/api": "^1.1.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "enhancedgv",
-  "version": "0.20.0",
+  "version": "0.19.0",
   "description": "Decky plugin that shows Steam store content (media, description, reviews, Deck compatibility, update history) on the library game page.",
   "type": "module",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "enhancedgv",
-  "version": "0.19.0",
+  "version": "0.20.0",
   "description": "Decky plugin that shows Steam store content (media, description, reviews, Deck compatibility, update history) on the library game page.",
   "type": "module",
   "scripts": {

--- a/plugin.json
+++ b/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "EnhancedGV",
   "author": "Featherwolf",
-  "version": "0.20.0",
+  "version": "0.19.0",
   "flags": [],
   "api_version": 1,
   "publish": {

--- a/plugin.json
+++ b/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "EnhancedGV",
   "author": "Featherwolf",
-  "version": "0.19.0",
+  "version": "0.20.0",
   "flags": [],
   "api_version": 1,
   "publish": {

--- a/scripts/check_callables.py
+++ b/scripts/check_callables.py
@@ -1,0 +1,43 @@
+"""Every callable the frontend invokes must exist on the backend Plugin class.
+
+This exists because it didn't: 63078f1 deleted `get_all_provider` while adding
+IGDB enrichment, and nothing noticed for three beta cuts. tsc cannot see across
+the bridge — callable<>("name") is just a string — so the contract needs its own
+check. Parses both sides rather than importing, so it is cheap and total.
+"""
+import ast, os, re, sys
+ROOT = os.environ.get("EGV_ROOT", os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+src = open(os.path.join(ROOT, "main.py"), encoding="utf-8").read()
+backend = set()
+for node in ast.parse(src).body:
+    if isinstance(node, ast.ClassDef) and node.name == "Plugin":
+        backend = {m.name for m in node.body
+                   if isinstance(m, (ast.FunctionDef, ast.AsyncFunctionDef))}
+
+wanted = {}
+for dirpath, _dirs, files in os.walk(os.path.join(ROOT, "src")):
+    for fn in files:
+        if not fn.endswith((".ts", ".tsx")):
+            continue
+        path = os.path.join(dirpath, fn)
+        text = open(path, encoding="utf-8").read()
+        # callable<...>("name")  — the generic may span lines
+        for m in re.finditer(r'callable\s*<.*?>\s*\(\s*["\']([A-Za-z_][A-Za-z0-9_]*)["\']',
+                             text, re.S):
+            wanted.setdefault(m.group(1), os.path.relpath(path, ROOT))
+
+assert backend, "could not parse the Plugin class"
+assert wanted, "found no callables in src/ — the regex is wrong, not the code"
+
+missing = sorted((n, f) for n, f in wanted.items() if n not in backend)
+print(f"{len(wanted)} callables referenced by the frontend; "
+      f"{len(backend)} methods on Plugin")
+for name in sorted(wanted):
+    print(f"  {'OK  ' if name in backend else 'MISS'} {name}")
+if missing:
+    print("\nFAIL — the frontend calls backend methods that do not exist:")
+    for name, where in missing:
+        print(f"  {name}  (referenced in {where})")
+    sys.exit(1)
+print("\nPASS — every frontend callable resolves to a Plugin method")

--- a/scripts/check_version.py
+++ b/scripts/check_version.py
@@ -1,0 +1,94 @@
+#!/usr/bin/env python3
+"""Fail the build when the version numbers disagree.
+
+This repo has been bitten twice by version drift that CI happily went green on:
+
+  * 4b1adc2 / 1271d5d shipped `package.json` 0.19.0 next to `plugin.json` 0.18.0.
+    Decky reads plugin.json, so the plugin would have DISPLAYED the wrong
+    version while its own updater compared the other one.
+  * Two feature lines independently claimed 0.19.0, which forced a renumber.
+
+So: one job, no network, runs right after checkout, and says exactly which file
+disagrees with which.
+
+Run locally with no arguments; CI additionally passes the pushed ref so a tag can
+be checked against the tree it points at.
+"""
+import json
+import os
+import re
+import sys
+
+ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+SEMVER = re.compile(r"^\d+\.\d+\.\d+$")
+
+
+def read_json(name):
+    with open(os.path.join(ROOT, name), "r", encoding="utf-8") as fh:
+        return json.load(fh)
+
+
+def main() -> int:
+    errors = []
+
+    pkg = read_json("package.json").get("version", "")
+    plug = read_json("plugin.json").get("version", "")
+
+    if pkg != plug:
+        errors.append(
+            f"package.json says {pkg!r} but plugin.json says {plug!r}.\n"
+            f"    plugin.json is what Decky displays; package.json is what the "
+            f"in-plugin updater compares. They must match."
+        )
+    if not SEMVER.match(pkg):
+        errors.append(f"package.json version {pkg!r} is not a bare X.Y.Z.")
+
+    # The release job slices release notes out of CHANGELOG.md with an EXACT
+    # `^## v<version>\n` match, while main.py's patch-notes modal tolerates
+    # trailing whitespace. A heading with a stray space therefore ships empty
+    # release notes while looking fine in the plugin — so require the exact form.
+    with open(os.path.join(ROOT, "CHANGELOG.md"), "r", encoding="utf-8") as fh:
+        changelog = fh.read()
+    section = re.search(
+        rf"^## v{re.escape(pkg)}$\n(.*?)(?=^## |\Z)", changelog, re.S | re.M
+    )
+    if not section:
+        loose = re.search(rf"^## v{re.escape(pkg)}\s*$", changelog, re.M)
+        errors.append(
+            f"CHANGELOG.md has no exact '## v{pkg}' heading."
+            + (
+                "\n    A heading for that version exists but has trailing "
+                "whitespace, which silently empties the release notes."
+                if loose
+                else ""
+            )
+        )
+    elif not section.group(1).strip():
+        errors.append(f"CHANGELOG.md section '## v{pkg}' is empty.")
+
+    # On a tag push, the tag must describe the tree it points at. `v0.19.0` and
+    # `v0.19.0-beta` both map to 0.19.0 — a beta carries the version it becomes.
+    ref_type = os.environ.get("GITHUB_REF_TYPE", "")
+    ref_name = os.environ.get("GITHUB_REF_NAME", "")
+    if ref_type == "tag" and ref_name:
+        tag_version = re.sub(r"-.*$", "", ref_name.lstrip("v"))
+        if tag_version != pkg:
+            errors.append(
+                f"tag {ref_name!r} implies version {tag_version!r}, but the tree "
+                f"says {pkg!r}. Tag the commit that carries the version."
+            )
+
+    if errors:
+        print("Version consistency check FAILED:\n", file=sys.stderr)
+        for e in errors:
+            print(f"  - {e}", file=sys.stderr)
+        return 1
+
+    print(f"Version consistency OK: {pkg} (package.json == plugin.json, "
+          f"CHANGELOG section present"
+          + (f", tag {ref_name} matches" if ref_type == "tag" else "") + ")")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/src/api.ts
+++ b/src/api.ts
@@ -108,6 +108,22 @@ export interface BackendInfo {
 }
 export const getBackendInfo = callable<[], BackendInfo>("get_backend_info");
 
+export interface IgdbStep {
+  name: string;
+  ok: boolean;
+  detail: string;
+}
+export interface IgdbTest {
+  ok: boolean;
+  error?: string;
+  steps: IgdbStep[];
+  igdb_id?: number;
+  name?: string;
+  sample_image?: string;
+}
+// Per-step probe of the IGDB enrichment path. Never returns the key itself.
+export const testIgdb = callable<[game_appid: number], IgdbTest>("test_igdb");
+
 export interface VideoProbe {
   url: string;
   status: number;

--- a/src/api.ts
+++ b/src/api.ts
@@ -124,6 +124,12 @@ export interface IgdbTest {
 // Per-step probe of the IGDB enrichment path. Never returns the key itself.
 export const testIgdb = callable<[game_appid: number], IgdbTest>("test_igdb");
 
+// Removal needs its own call: get_settings redacts the secret, so set_settings
+// treats an absent one as "keep" — otherwise any unrelated save would wipe it.
+export const clearIgdbCredentials = callable<[], { ok: boolean; error?: string }>(
+  "clear_igdb_credentials",
+);
+
 export interface VideoProbe {
   url: string;
   status: number;

--- a/src/components/DescriptionSection.tsx
+++ b/src/components/DescriptionSection.tsx
@@ -19,14 +19,20 @@ const HTML_STYLE = `
 // scrolls through it in place (the page follows focus) without needing the QAM
 // modal or right-stick scrolling.
 export function DescriptionSection({ aboutHtml, short }: Props) {
-  const html = aboutHtml || short;
-  if (!html) {
-    return <div style={{ opacity: 0.6, fontSize: 13 }}>No description available.</div>;
+  // `aboutHtml` has been through the backend's allowlist sanitizer. `short` has
+  // NOT — it is a plain-text field, passed through verbatim — so it must never
+  // reach FocusableBlocks, whose only sink is dangerouslySetInnerHTML. Using it
+  // as an HTML fallback turned an unsanitized string into markup.
+  if (aboutHtml) {
+    return (
+      <div>
+        <style>{HTML_STYLE}</style>
+        <FocusableBlocks html={aboutHtml} blockClass="ssp-desc" />
+      </div>
+    );
   }
-  return (
-    <div>
-      <style>{HTML_STYLE}</style>
-      <FocusableBlocks html={html} blockClass="ssp-desc" />
-    </div>
-  );
+  if (short) {
+    return <div style={{ fontSize: 13.5, lineHeight: 1.5 }}>{short}</div>;
+  }
+  return <div style={{ opacity: 0.6, fontSize: 13 }}>No description available.</div>;
 }

--- a/src/components/FeaturesSection.tsx
+++ b/src/components/FeaturesSection.tsx
@@ -1,5 +1,6 @@
 import type { ReactNode } from "react";
-import { Focusable, Navigation } from "@decky/ui";
+import { openExternal } from "../nav";
+import { Focusable } from "@decky/ui";
 import type { AppDetails } from "../types";
 import { FOCUS_SCROLL_MARGIN } from "../focus";
 
@@ -76,7 +77,7 @@ export function FeaturesSection({ d }: { d: AppDetails }) {
                 <Focusable
                   onActivate={() =>
                     d.metacritic?.url &&
-                    Navigation.NavigateToExternalWeb(d.metacritic.url)
+                    openExternal(d.metacritic.url)
                   }
                   style={{
                     ...FOCUS_SCROLL_MARGIN,

--- a/src/components/NewsSection.tsx
+++ b/src/components/NewsSection.tsx
@@ -3,9 +3,9 @@ import {
   DialogButton,
   showModal,
   ModalRoot,
-  Navigation,
 } from "@decky/ui";
 import type { News, NewsItem } from "../types";
+import { openExternal } from "../nav";
 import { FOCUS_SCROLL_MARGIN, CENTER_ON_FOCUS } from "../focus";
 
 function fmtDate(unix: number): string {
@@ -53,7 +53,7 @@ function NewsModal({
         />
         {item.url && (
           <DialogButton
-            onClick={() => Navigation.NavigateToExternalWeb(item.url)}
+            onClick={() => openExternal(item.url)}
           >
             View on Steam
           </DialogButton>

--- a/src/components/QuickAccessSettings.tsx
+++ b/src/components/QuickAccessSettings.tsx
@@ -291,11 +291,11 @@ function IgdbKeyRow() {
     <>
       <PanelSectionRow>
         <TextField
-          label="Hasheous API key (optional)"
+          label="Hasheous client API key (optional)"
           description={
             saved
               ? "A key is saved. With one, retro games get IGDB covers, screenshots, genres and developers instead of just a logo and description."
-              : "Without a key you get the keyless baseline: logo + description. Paste a Hasheous client API key to add IGDB covers and screenshots."
+              : "Without a key you get the keyless baseline: logo + description. Add IGDB covers and screenshots with a free key: register at hasheous.org, create an App, then use 'Create Client API Key' on that app's page. This is NOT the Submission API Key on your profile — that one is rejected. Full steps are in the plugin README."
           }
           value={key}
           bIsPassword

--- a/src/components/QuickAccessSettings.tsx
+++ b/src/components/QuickAccessSettings.tsx
@@ -235,8 +235,9 @@ function StoreSourceSection({ appid, lang, cc }: { appid: number; lang: string; 
 // backend layers IGDB covers/screenshots/genres/developers over the keyless
 // baseline. The key lives in the plugin's local settings file and is sent only
 // to hasheous.org — the test below never echoes it back.
-function IgdbKeyRow() {
-  const [key, setKey] = useState<string>("");
+function IgdbCredentialsRow() {
+  const [clientId, setClientId] = useState<string>("");
+  const [clientSecret, setClientSecret] = useState<string>("");
   const [saved, setSaved] = useState<boolean>(false);
   const [busy, setBusy] = useState(false);
   const [steps, setSteps] = useState<IgdbStep[] | null>(null);
@@ -247,7 +248,9 @@ function IgdbKeyRow() {
     getSettings()
       .then((s) => {
         if (!alive) return;
-        setSaved(!!(s as PluginSettings).hasheousApiKey);
+        const st = s as PluginSettings;
+        setSaved(!!(st.igdbClientId && st.igdbClientSecret));
+        setClientId(st.igdbClientId ?? "");
       })
       .catch(() => undefined);
     return () => {
@@ -255,16 +258,20 @@ function IgdbKeyRow() {
     };
   }, []);
 
-  const save = async (value: string) => {
+  const save = async (id: string, secret: string) => {
     try {
       const cur = await getSettings();
-      const next = { ...(cur as PluginSettings), hasheousApiKey: value };
+      const next = { ...(cur as PluginSettings), igdbClientId: id, igdbClientSecret: secret };
       await setSettings(next);
       primeSettings(next);
-      setSaved(!!value);
-      setNote(value ? "Key saved." : "Key cleared — back to the keyless baseline.");
+      setSaved(!!(id && secret));
+      setNote(
+        id && secret
+          ? "Credentials saved."
+          : "Credentials cleared — back to the keyless baseline.",
+      );
       // Cached non-Steam payloads were built without artwork; drop them so the
-      // next visit refetches with the key in play.
+      // next visit refetches with IGDB in play.
       await clearCache().catch(() => undefined);
       clearFrontendCache();
     } catch (e) {
@@ -291,20 +298,32 @@ function IgdbKeyRow() {
     <>
       <PanelSectionRow>
         <TextField
-          label="Hasheous client API key (optional)"
+          label="IGDB Client ID (optional)"
           description={
             saved
-              ? "A key is saved. With one, retro games get IGDB covers, screenshots, genres and developers instead of just a logo and description."
-              : "Without a key you get the keyless baseline: logo + description. A key adds IGDB covers and screenshots. Note Hasheous only issues client API keys to registered applications, so most users cannot obtain one yet and stay on the baseline. If you do have one, it is the Client API Key from an application's page — NOT the Submission API Key on your profile, which is rejected."
+              ? "IGDB credentials are saved. Retro games get covers, screenshots, genres and developers instead of just a logo and description."
+              : "Without these you get the keyless baseline: logo + description. Free to obtain: create a Twitch account, enable two-factor, then register an application at dev.twitch.tv/console with Client Type set to Confidential. Full steps are in the plugin README."
           }
-          value={key}
-          bIsPassword
-          onChange={(e: { target: { value: string } }) => setKey(e.target.value)}
+          value={clientId}
+          onChange={(e: { target: { value: string } }) => setClientId(e.target.value)}
         />
       </PanelSectionRow>
       <PanelSectionRow>
-        <ButtonItem layout="below" onClick={() => save(key.trim())} disabled={!key.trim()}>
-          Save key
+        <TextField
+          label="IGDB Client Secret"
+          description="Generated with [New Secret] on that same Twitch application page. Stored on this device and sent only to id.twitch.tv to mint an access token."
+          value={clientSecret}
+          bIsPassword
+          onChange={(e: { target: { value: string } }) => setClientSecret(e.target.value)}
+        />
+      </PanelSectionRow>
+      <PanelSectionRow>
+        <ButtonItem
+          layout="below"
+          onClick={() => save(clientId.trim(), clientSecret.trim())}
+          disabled={!clientId.trim() || !clientSecret.trim()}
+        >
+          Save credentials
         </ButtonItem>
       </PanelSectionRow>
       {saved && (
@@ -312,11 +331,12 @@ function IgdbKeyRow() {
           <ButtonItem
             layout="below"
             onClick={() => {
-              setKey("");
-              void save("");
+              setClientId("");
+              setClientSecret("");
+              void save("", "");
             }}
           >
-            Remove key
+            Remove credentials
           </ButtonItem>
         </PanelSectionRow>
       )}
@@ -332,6 +352,7 @@ function IgdbKeyRow() {
     </>
   );
 }
+
 
 export function QuickAccessSettings() {
   const [settings, setLocal] = useState<PluginSettings>(DEFAULTS);
@@ -518,7 +539,7 @@ export function QuickAccessSettings() {
             onChange={toggleNonSteam}
           />
         </PanelSectionRow>
-        {!!settings.nonSteamSources && <IgdbKeyRow />}
+        {!!settings.nonSteamSources && <IgdbCredentialsRow />}
       </PanelSection>
 
       <PanelSection title="Sections shown on the game page">

--- a/src/components/QuickAccessSettings.tsx
+++ b/src/components/QuickAccessSettings.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useRef, useState } from "react";
+import { openExternal } from "../nav";
 import {
   PanelSection,
   PanelSectionRow,
@@ -6,7 +7,6 @@ import {
   ButtonItem,
   TextField,
   showModal,
-  Navigation,
 } from "@decky/ui";
 import { toaster, useQuickAccessVisible } from "@decky/api";
 import { getCurrentAppid } from "../patchLibraryApp";
@@ -656,7 +656,7 @@ export function QuickAccessSettings() {
               <PanelSectionRow>
                 <ButtonItem
                   layout="below"
-                  onClick={() => update.url && Navigation.NavigateToExternalWeb(update.url)}
+                  onClick={() => openExternal(update.url)}
                 >
                   Open the release page
                 </ButtonItem>

--- a/src/components/QuickAccessSettings.tsx
+++ b/src/components/QuickAccessSettings.tsx
@@ -389,8 +389,10 @@ export function QuickAccessSettings() {
   };
 
   const runUpdateCheck = async () => {
-    // Stable channel only — beta builds are private drafts, not offered in-app.
-    const info = await checkUpdate(false).catch(
+    // Beta builds are published as GitHub PRE-RELEASES: excluded from
+    // /releases/latest (so stable users never see them) but visible to the
+    // beta channel, which opts in here.
+    const info = await checkUpdate(!!settings.beta).catch(
       (e) => ({ ok: false, error: String(e), current: "?" }) as UpdateInfo
     );
     setUpdate(info);
@@ -578,6 +580,20 @@ export function QuickAccessSettings() {
           <ButtonItem layout="below" onClick={runUpdateCheck}>
             Check for updates
           </ButtonItem>
+        </PanelSectionRow>
+        <PanelSectionRow>
+          <ToggleField
+            label="Beta channel (test builds)"
+            description="Include pre-release test builds in the update check. Off by default. A beta carries the version number it will become, and you'll be offered the final release when it ships."
+            checked={!!settings.beta}
+            onChange={(v: boolean) => {
+              persist({ ...settings, beta: v });
+              // Re-run immediately so the readout reflects the channel just chosen.
+              void checkUpdate(v)
+                .then(setUpdate)
+                .catch((e) => setUpdate({ ok: false, error: String(e), current: "?" } as UpdateInfo));
+            }}
+          />
         </PanelSectionRow>
         {update?.ok && update.has_update && (
           <>

--- a/src/components/QuickAccessSettings.tsx
+++ b/src/components/QuickAccessSettings.tsx
@@ -20,6 +20,7 @@ import {
   getBackendInfo,
   resolveGame,
   testIgdb,
+  clearIgdbCredentials,
   lookupStoreApp,
   setMatch,
   clearMatch,
@@ -249,7 +250,8 @@ function IgdbCredentialsRow() {
       .then((s) => {
         if (!alive) return;
         const st = s as PluginSettings;
-        setSaved(!!(st.igdbClientId && st.igdbClientSecret));
+        // The backend redacts the secret and reports only whether one exists.
+        setSaved(!!(st.igdbClientId && st.igdbClientSecretSet));
         setClientId(st.igdbClientId ?? "");
       })
       .catch(() => undefined);
@@ -263,13 +265,11 @@ function IgdbCredentialsRow() {
       const cur = await getSettings();
       const next = { ...(cur as PluginSettings), igdbClientId: id, igdbClientSecret: secret };
       await setSettings(next);
-      primeSettings(next);
+      // Never keep the secret in the object handed around the frontend.
+      primeSettings({ ...next, igdbClientSecret: "", igdbClientSecretSet: !!secret });
+      setClientSecret("");
       setSaved(!!(id && secret));
-      setNote(
-        id && secret
-          ? "Credentials saved."
-          : "Credentials cleared — back to the keyless baseline.",
-      );
+      setNote("Credentials saved.");
       // Cached non-Steam payloads were built without artwork; drop them so the
       // next visit refetches with IGDB in play.
       await clearCache().catch(() => undefined);
@@ -331,9 +331,21 @@ function IgdbCredentialsRow() {
           <ButtonItem
             layout="below"
             onClick={() => {
-              setClientId("");
-              setClientSecret("");
-              void save("", "");
+              void (async () => {
+                setClientId("");
+                setClientSecret("");
+                try {
+                  await clearIgdbCredentials();
+                  const cur = await getSettings();
+                  primeSettings(cur as PluginSettings);
+                  setSaved(false);
+                  setNote("Credentials cleared — back to the keyless baseline.");
+                  await clearCache().catch(() => undefined);
+                  clearFrontendCache();
+                } catch (e) {
+                  setNote(`Could not clear: ${String(e)}`);
+                }
+              })();
             }}
           >
             Remove credentials

--- a/src/components/QuickAccessSettings.tsx
+++ b/src/components/QuickAccessSettings.tsx
@@ -19,12 +19,13 @@ import {
   testVideo,
   getBackendInfo,
   resolveGame,
+  testIgdb,
   lookupStoreApp,
   setMatch,
   clearMatch,
   blankMatch,
 } from "../api";
-import type { VideoProbe, BackendInfo, ResolveResult } from "../api";
+import type { VideoProbe, BackendInfo, ResolveResult, IgdbStep } from "../api";
 import type { UpdateInfo } from "../types";
 import { getGameIdentity } from "../identity";
 import { providerLabel } from "../providers";
@@ -230,6 +231,108 @@ function StoreSourceSection({ appid, lang, cc }: { appid: number; lang: string; 
   );
 }
 
+// Artwork upgrade for non-Steam games: paste a Hasheous CLIENT API key and the
+// backend layers IGDB covers/screenshots/genres/developers over the keyless
+// baseline. The key lives in the plugin's local settings file and is sent only
+// to hasheous.org — the test below never echoes it back.
+function IgdbKeyRow() {
+  const [key, setKey] = useState<string>("");
+  const [saved, setSaved] = useState<boolean>(false);
+  const [busy, setBusy] = useState(false);
+  const [steps, setSteps] = useState<IgdbStep[] | null>(null);
+  const [note, setNote] = useState<string>("");
+
+  useEffect(() => {
+    let alive = true;
+    getSettings()
+      .then((s) => {
+        if (!alive) return;
+        setSaved(!!(s as PluginSettings).hasheousApiKey);
+      })
+      .catch(() => undefined);
+    return () => {
+      alive = false;
+    };
+  }, []);
+
+  const save = async (value: string) => {
+    try {
+      const cur = await getSettings();
+      const next = { ...(cur as PluginSettings), hasheousApiKey: value };
+      await setSettings(next);
+      primeSettings(next);
+      setSaved(!!value);
+      setNote(value ? "Key saved." : "Key cleared — back to the keyless baseline.");
+      // Cached non-Steam payloads were built without artwork; drop them so the
+      // next visit refetches with the key in play.
+      await clearCache().catch(() => undefined);
+      clearFrontendCache();
+    } catch (e) {
+      setNote(`Could not save: ${String(e)}`);
+    }
+  };
+
+  const runTest = async () => {
+    setBusy(true);
+    setSteps(null);
+    setNote("");
+    try {
+      const res = await testIgdb(getCurrentAppid() ?? 0);
+      setSteps(res.steps ?? []);
+      if (!res.ok && res.error) setNote(res.error);
+    } catch (e) {
+      setNote(String(e));
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  return (
+    <>
+      <PanelSectionRow>
+        <TextField
+          label="Hasheous API key (optional)"
+          description={
+            saved
+              ? "A key is saved. With one, retro games get IGDB covers, screenshots, genres and developers instead of just a logo and description."
+              : "Without a key you get the keyless baseline: logo + description. Paste a Hasheous client API key to add IGDB covers and screenshots."
+          }
+          value={key}
+          bIsPassword
+          onChange={(e: { target: { value: string } }) => setKey(e.target.value)}
+        />
+      </PanelSectionRow>
+      <PanelSectionRow>
+        <ButtonItem layout="below" onClick={() => save(key.trim())} disabled={!key.trim()}>
+          Save key
+        </ButtonItem>
+      </PanelSectionRow>
+      {saved && (
+        <PanelSectionRow>
+          <ButtonItem
+            layout="below"
+            onClick={() => {
+              setKey("");
+              void save("");
+            }}
+          >
+            Remove key
+          </ButtonItem>
+        </PanelSectionRow>
+      )}
+      <PanelSectionRow>
+        <ButtonItem layout="below" onClick={runTest} disabled={busy}>
+          {busy ? "Testing…" : "Test artwork lookup"}
+        </ButtonItem>
+      </PanelSectionRow>
+      {steps?.map((st) => (
+        <DiagRow key={st.name} label={st.name} value={`${st.ok ? "✔" : "✖"} ${st.detail}`} />
+      ))}
+      {!!note && <DiagRow label="Result" value={note} />}
+    </>
+  );
+}
+
 export function QuickAccessSettings() {
   const [settings, setLocal] = useState<PluginSettings>(DEFAULTS);
   const [diag, setDiag] = useState<DiagState>(getDiag());
@@ -399,6 +502,7 @@ export function QuickAccessSettings() {
             onChange={toggleNonSteam}
           />
         </PanelSectionRow>
+        {!!settings.nonSteamSources && <IgdbKeyRow />}
       </PanelSection>
 
       <PanelSection title="Sections shown on the game page">

--- a/src/components/QuickAccessSettings.tsx
+++ b/src/components/QuickAccessSettings.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import {
   PanelSection,
   PanelSectionRow,
@@ -346,6 +346,7 @@ export function QuickAccessSettings() {
   const [navBridge, setNavBridge] = useState(getNavBridgeNote());
   const [showAdvanced, setShowAdvanced] = useState(false);
   const [update, setUpdate] = useState<UpdateInfo | null>(null);
+  const [settingsLoaded, setSettingsLoaded] = useState(false);
   const [backendInfo, setBackendInfo] = useState<BackendInfo | null>(null);
   const qamVisible = useQuickAccessVisible();
   const [videoTest, setVideoTest] = useState<string>("");
@@ -388,14 +389,18 @@ export function QuickAccessSettings() {
     }
   };
 
-  const runUpdateCheck = async () => {
+  // Monotonic request id: the channel can flip while a check is in flight,
+  // and the OLDER response must not land on top of the newer one.
+  const updateReq = useRef(0);
+  const runUpdateCheck = async (beta: boolean = !!settings.beta) => {
     // Beta builds are published as GitHub PRE-RELEASES: excluded from
     // /releases/latest (so stable users never see them) but visible to the
     // beta channel, which opts in here.
-    const info = await checkUpdate(!!settings.beta).catch(
+    const id = ++updateReq.current;
+    const info = await checkUpdate(beta).catch(
       (e) => ({ ok: false, error: String(e), current: "?" }) as UpdateInfo
     );
-    setUpdate(info);
+    if (id === updateReq.current) setUpdate(info);
   };
 
 
@@ -415,6 +420,7 @@ export function QuickAccessSettings() {
           sections: { ...DEFAULTS.sections, ...s?.sections },
           expanded: { ...DEFAULT_EXPANDED, ...s?.expanded },
         });
+        setSettingsLoaded(true);
       })
       .catch((e) => {
         settled = true;
@@ -434,9 +440,17 @@ export function QuickAccessSettings() {
   // Poll the synchronous probes ONLY while the QAM is actually visible —
   // otherwise a hidden panel re-renders twice a second forever after the
   // overlay closes (thousands of orphan renders + timer churn on battery).
+  // The automatic update check must wait for the SAVED settings: running it
+  // from the initial DEFAULTS closure checked the stable channel even when the
+  // user had the beta channel on, and nothing re-ran it once settings loaded.
+  useEffect(() => {
+    if (!qamVisible || !settingsLoaded) return;
+    void runUpdateCheck(!!settings.beta);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [qamVisible, settingsLoaded, settings.beta]);
+
   useEffect(() => {
     if (!qamVisible) return;
-    runUpdateCheck();
     const iv = setInterval(() => {
       setStoreRenders(getStoreRenders());
       setFetch(describeFetch());
@@ -577,7 +591,7 @@ export function QuickAccessSettings() {
           </ButtonItem>
         </PanelSectionRow>
         <PanelSectionRow>
-          <ButtonItem layout="below" onClick={runUpdateCheck}>
+          <ButtonItem layout="below" onClick={() => void runUpdateCheck()}>
             Check for updates
           </ButtonItem>
         </PanelSectionRow>
@@ -586,13 +600,9 @@ export function QuickAccessSettings() {
             label="Beta channel (test builds)"
             description="Include pre-release test builds in the update check. Off by default. A beta carries the version number it will become, and you'll be offered the final release when it ships."
             checked={!!settings.beta}
-            onChange={(v: boolean) => {
-              persist({ ...settings, beta: v });
-              // Re-run immediately so the readout reflects the channel just chosen.
-              void checkUpdate(v)
-                .then(setUpdate)
-                .catch((e) => setUpdate({ ok: false, error: String(e), current: "?" } as UpdateInfo));
-            }}
+            // Persisting flips settings.beta, which re-runs the update check
+            // for the newly chosen channel via the effect above.
+            onChange={(v: boolean) => persist({ ...settings, beta: v })}
           />
         </PanelSectionRow>
         {update?.ok && update.has_update && (

--- a/src/components/QuickAccessSettings.tsx
+++ b/src/components/QuickAccessSettings.tsx
@@ -295,7 +295,7 @@ function IgdbKeyRow() {
           description={
             saved
               ? "A key is saved. With one, retro games get IGDB covers, screenshots, genres and developers instead of just a logo and description."
-              : "Without a key you get the keyless baseline: logo + description. Add IGDB covers and screenshots with a free key: register at hasheous.org, create an App, then use 'Create Client API Key' on that app's page. This is NOT the Submission API Key on your profile — that one is rejected. Full steps are in the plugin README."
+              : "Without a key you get the keyless baseline: logo + description. A key adds IGDB covers and screenshots. Note Hasheous only issues client API keys to registered applications, so most users cannot obtain one yet and stay on the baseline. If you do have one, it is the Client API Key from an application's page — NOT the Submission API Key on your profile, which is rejected."
           }
           value={key}
           bIsPassword

--- a/src/components/StorePanel.tsx
+++ b/src/components/StorePanel.tsx
@@ -3,7 +3,7 @@ import type { CSSProperties, ReactNode } from "react";
 import { Focusable } from "@decky/ui";
 import { useAppData } from "../hooks/useAppData";
 import { useResolvedGame } from "../hooks/useResolvedGame";
-import { steamAppidOf } from "../providers";
+import { steamAppidOf, providerLabel } from "../providers";
 import { CENTER_ON_FOCUS, FOCUS_SCROLL_MARGIN, focusFirstStop } from "../focus";
 import {
   setDiag,
@@ -318,6 +318,14 @@ export function StorePanel({ appid, slot = "primary", fallback }: Props) {
   // sections show a shimmer rather than their empty state, and their subtitle
   // (review count, news count, Deck rating) fills in when the data lands.
   const pending = !!data.partial;
+  // Non-Steam content is worth attributing: the panel otherwise looks like a
+  // Steam store page, and which database supplied it changes what to expect
+  // (no reviews, no Deck rating, and artwork only when IGDB enrichment ran).
+  const provider = fetchRef?.provider ?? "steam";
+  const sourceNote =
+    provider === "steam"
+      ? ""
+      : `via ${providerLabel(provider)}${d.igdb_enriched ? " + IGDB" : ""}`;
   const expanded = { ...DEFAULT_EXPANDED, ...settings.expanded };
   const reviewSummary = data.reviews?.ok ? data.reviews.summary.desc : "";
 
@@ -384,6 +392,9 @@ export function StorePanel({ appid, slot = "primary", fallback }: Props) {
       <div style={{ display: "flex", alignItems: "center", gap: 10, flexWrap: "wrap" }}>
         {reviewSummary && (
           <span style={{ fontSize: 12.5, opacity: 0.85 }}>{reviewSummary}</span>
+        )}
+        {sourceNote && (
+          <span style={{ fontSize: 12, opacity: 0.6 }}>{sourceNote}</span>
         )}
         {data.deck?.ok && <DeckCompatBadge deck={data.deck} />}
       </div>

--- a/src/dashPlayer.ts
+++ b/src/dashPlayer.ts
@@ -42,8 +42,14 @@ function parseDurationSec(v: string | null): number {
 }
 
 function repsFrom(doc: Document): { video: Rep[]; audio: Rep[]; durationSec: number } {
-  const durationSec = parseDurationSec(
-    doc.documentElement.getAttribute("mediaPresentationDuration")
+  // Clamped at the boundary: this value comes from the manifest, i.e. from the
+  // network, and a declared PT999999H would otherwise drive the segment loop
+  // effectively for ever. Nothing legitimate here runs longer than an hour.
+  const durationSec = Math.min(
+    Math.max(parseDurationSec(
+      doc.documentElement.getAttribute("mediaPresentationDuration")
+    ) || 0, 0),
+    3600,
   );
   const video: Rep[] = [];
   const audio: Rep[] = [];
@@ -79,9 +85,13 @@ function repsFrom(doc: Document): { video: Rep[]; audio: Rep[]; durationSec: num
 function fillTemplate(tpl: string, repId: string, num?: number): string {
   let out = tpl.replace(/\$RepresentationID\$/g, repId);
   if (num != null) {
-    out = out.replace(/\$Number(%0(\d+)d)?\$/g, (_m, _pad, width) =>
-      width ? String(num).padStart(parseInt(width), "0") : String(num)
-    );
+    out = out.replace(/\$Number(%0(\d+)d)?\$/g, (_m, _pad, width) => {
+      // The width comes from the manifest, i.e. from the network. padStart with
+      // an unbounded width allocates that many bytes PER SEGMENT — a declared
+      // width of 268435456 is a 256 MB string each time round the loop.
+      const w = Math.min(parseInt(width) || 0, 12);
+      return w > 0 ? String(num).padStart(w, "0") : String(num);
+    });
   }
   return out;
 }
@@ -149,8 +159,10 @@ export async function playDashInto(
 
   const base = mpdUrl.split("?")[0].replace(/[^/]*$/, "");
   const query = mpdUrl.includes("?") ? "?" + mpdUrl.split("?")[1] : "";
+  // Segment count is derived from a manifest-declared duration, so it is also
+  // attacker-controlled. Cap it: 4000 segments is far more than any trailer.
   const segCount = (r: Rep) =>
-    Math.max(1, Math.ceil((durationSec * r.timescale) / r.segDuration));
+    Math.min(4000, Math.max(1, Math.ceil((durationSec * r.timescale) / r.segDuration)));
 
   const ms = new MS();
   const objectUrl = win.URL.createObjectURL(ms);

--- a/src/nav.ts
+++ b/src/nav.ts
@@ -1,0 +1,15 @@
+import { Navigation } from "@decky/ui";
+
+/**
+ * Open an external URL, but only if it is plainly http(s).
+ *
+ * Every URL reaching these call sites comes from a third-party response. The
+ * backend already filters them, but this is the last gate before the Steam
+ * client acts on the string — and `steam://` is a live command channel to the
+ * client, so a cache written by an older build must not be able to reach it.
+ */
+export function openExternal(url: unknown): void {
+  const u = String(url ?? "");
+  if (!/^https?:\/\/[^/\s]/i.test(u)) return;
+  Navigation.NavigateToExternalWeb(u);
+}

--- a/src/types.ts
+++ b/src/types.ts
@@ -66,6 +66,9 @@ export interface AppDetails {
   recommendations_total: number | null;
   achievements_total: number | null;
   supported_languages_html: string;
+  // Set by the backend when the IGDB pass added artwork/details on top of the
+  // keyless Hasheous baseline (drives the source note in the panel).
+  igdb_enriched?: boolean;
   pc_requirements: Requirements | null;
   content_descriptor_notes: string | null;
 }
@@ -197,6 +200,9 @@ export interface PluginSettings {
   language: string;
   country: string;
   beta?: boolean; // opt in to pre-release update checks
+  // Hasheous CLIENT API key. Empty = keyless baseline (logo + description);
+  // set = IGDB artwork/details for non-Steam games. Stored locally only.
+  hasheousApiKey?: string;
   // Opt in to pulling metadata for non-Steam / emulated games from external
   // sources (Hasheous). OFF by default — when off, non-Steam games behave exactly
   // as before (Steam title-search only, then "unmatched").

--- a/src/types.ts
+++ b/src/types.ts
@@ -202,7 +202,8 @@ export interface PluginSettings {
   beta?: boolean; // opt in to pre-release update checks
   // Hasheous CLIENT API key. Empty = keyless baseline (logo + description);
   // set = IGDB artwork/details for non-Steam games. Stored locally only.
-  hasheousApiKey?: string;
+  igdbClientId?: string;
+  igdbClientSecret?: string;
   // Opt in to pulling metadata for non-Steam / emulated games from external
   // sources (Hasheous). OFF by default — when off, non-Steam games behave exactly
   // as before (Steam title-search only, then "unmatched").

--- a/src/types.ts
+++ b/src/types.ts
@@ -204,6 +204,8 @@ export interface PluginSettings {
   // set = IGDB artwork/details for non-Steam games. Stored locally only.
   igdbClientId?: string;
   igdbClientSecret?: string;
+  /** Backend-reported: a secret is stored. The secret itself is never sent. */
+  igdbClientSecretSet?: boolean;
   // Opt in to pulling metadata for non-Steam / emulated games from external
   // sources (Hasheous). OFF by default — when off, non-Steam games behave exactly
   // as before (Steam title-search only, then "unmatched").


### PR DESCRIPTION
Brings `main` up to the beta line (the tree published as `v0.19.0-beta.8`) and rewrites the changelog section that becomes the release notes.

## What's in it

24 commits already tested on `beta`, plus one new commit here. `main` has nothing that `beta` doesn't, so this is a fast-forward in content: the non-Steam / emulated game metadata path (Hasheous keyless baseline + optional IGDB artwork), the matching and manual-override work, the seventeen security fixes, and the game-page load-time work that was already on `main`'s own 0.19.0 line.

## The one new commit

`CHANGELOG.md` only — no code changes. The `## v0.19.0` section was written for beta testers and is what the release workflow slices out as the published release notes, so it needed to read as a release:

- Dropped the tester framing — the "Testing non-Steam / emulated game metadata" heading, and the closing "Please report … you are the first to exercise it".
- Dropped three "Fixed since beta.N" blocks. They describe bugs that only existed in unreleased beta builds; someone upgrading from v0.18.0 never saw them.
- **Restored a line that had gone missing.** `a0acd7b` removed the tester block above the main feature bullet and took that bullet's first line with it, so the release's headline item has been starting mid-sentence ("a non-Steam game has no Steam store page, …") in the published beta.8 notes.
- Kept the IGDB setup steps and the diagnostic table, now as their own subsection rather than "Step 2" of a test script — they're for anyone enabling the feature, not just testers.
- Reworded the security note about the three findings that predate this release: once this ships, v0.18.0 is no longer "the current stable release".

## Versions

No bump needed. `package.json` and `plugin.json` already read `0.19.0` — a beta carries the version it becomes — so the `v0.19.0` tag matches the tree.

## Releasing

The tag does the work, not this merge. Pushing `v0.19.0` publishes the release as `--latest` and the workflow then retires every `v0.19.0-beta.*` pre-release and tag automatically, so beta.8 does not need deleting by hand.

## Checks

- `scripts/check_version.py` — pass (0.19.0 consistent, exact CHANGELOG heading present)
- `scripts/check_callables.py` — pass (18 frontend callables, all resolve)
- Release-notes extraction simulated for tag `v0.19.0` — 11,125 characters, non-empty, well-formed
- Test suite: contract 53, security 70, matching 34, IGDB transport 34, provider path 20, summary 29, plus cache, SWR, beta-channel, version-tuple and release-notes suites — all pass

One test, `test_tls_guard.py`, fails on its last section in this environment: it makes a live call to `id.twitch.tv` with dummy credentials and gets an HTTP 400. Its actual assertions — that credentials are refused when TLS verification is unavailable — pass. Not related to this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JWGu2oG8Q4XtgVyBbuqFdm

---
_Generated by [Claude Code](https://claude.ai/code/session_01JWGu2oG8Q4XtgVyBbuqFdm)_